### PR TITLE
Phase 5: Tracked documentation & learning material (architecture, runbook, agent guide, ADRs)

### DIFF
--- a/.github/pdm/workflows/compliance-guardrail.yml
+++ b/.github/pdm/workflows/compliance-guardrail.yml
@@ -1,5 +1,8 @@
 name: PDM Compliance & Security Guardrail
 
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# Scans the PR base..head with trufflehog and posts a pass/fail comment on PR runs.
+
 on:
   pull_request:
     branches: [ main ]

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -1,5 +1,8 @@
 name: PDM Quality Gate (Status Check)
 
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# This is the required status check on main; it posts a gate summary comment or uploads a gate-report artifact on non-PR runs.
+
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/compliance-guardrail.yml
+++ b/.github/workflows/compliance-guardrail.yml
@@ -1,5 +1,8 @@
 name: PDM Compliance & Security Guardrail
 
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# Scans the PR base..head with trufflehog and posts a pass/fail comment on PR runs.
+
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,5 +1,8 @@
 name: PDM Quality Gate (Status Check)
 
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# This is the required status check on main; it posts a gate summary comment or uploads a gate-report artifact on non-PR runs.
+
 on:
   pull_request:
     branches: [ main ]

--- a/README.md
+++ b/README.md
@@ -45,3 +45,11 @@ Workflows are verified by running them on GitHub — no local Docker/`act` harne
 `push` to `main` also triggers `release-pipeline` (real `createDeployment`); `workflow_dispatch` defaults to `dry_run: true` so manual runs skip the Deployment API.
 
 See `docs/ROADMAP.md` for the full delivery-engine roadmap and phase breakdown.
+
+## Documentation Shortcuts
+
+- [docs/architecture.md](docs/architecture.md) — workflow map, PR-gate pipeline diagram, promotion chain, canonical/mirror layout.
+- [docs/local-runbook.md](docs/local-runbook.md) — Native Runbook: testing the delivery engine on GitHub (`make sync`/`lint`/`test-gh`, `workflow_dispatch`, troubleshooting).
+- [docs/agents-guide.md](docs/agents-guide.md) — contributor and agent guide (extended `AGENTS.md` with the hard-earned gotchas).
+- [docs/decisions/](docs/decisions/) — ADR decision log for the delivery engine.
+- [docs/ROADMAP.md](docs/ROADMAP.md) — full delivery-engine roadmap and phase breakdown.

--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -1,0 +1,51 @@
+# Contributor & Agent Guide
+
+This is the tracked, extended form of `AGENTS.md` — read that file first (it is loaded automatically for agents), and keep it in sync with this guide.
+
+## What this is
+
+A PDM (Product Delivery Management) reference repo — a minimal Node service plus GitHub Actions workflows that exercise the PDM delivery gates. "PDM" here means Product Delivery Management, **not** the Python package manager.
+
+The engine is the GitHub Actions setup under `.github/`. Application code (a minimal Node 22 service with eslint, `node --test`, and a build script producing `dist/`) exists only so the quality gate and release build have real work.
+
+## Repository layout
+
+- `.github/pdm/workflows/` — canonical workflow definitions (source of truth).
+- `.github/workflows/` — GitHub-only execution copies, kept byte-identical via `make sync`.
+- `.github/pdm/{reports,deployments,releases}/` — run-artifact staging dirs written by workflows; never committed.
+- `scripts/` — Node helpers used by workflows (`build.mjs`, `risk-review.mjs`).
+- `src/` — the minimal Node service.
+- `docs/` — architecture, native runbook, agent guide, ROADMAP, and the ADR decision log.
+- `Makefile` — `sync`, `lint`, `test-gh` targets.
+
+## GitHub native workflow testing (the main task in this repo)
+
+Workflows are verified by running them on GitHub — there is no local `act`/Docker harness. Requires the `gh` CLI (`gh auth login`) and push access.
+
+```sh
+make lint      # actionlint on canonical + execution copies, then drift check
+make sync      # mirror .github/pdm/workflows/*.yml → .github/workflows/
+make test-gh   # push current branch + open/update a PR to main, then gh pr checks --watch
+```
+
+Edit only `.github/pdm/workflows/` and re-sync. Open a PR to `main` and GitHub runs the three PR workflows natively; the release pipeline is exercised via `workflow_dispatch` (default `dry_run: true`). On PR runs the workflows post comments; on non-PR (`workflow_dispatch`) runs they upload report/deployment records as run artifacts instead.
+
+## Hard-earned gotchas
+
+- **`osv-scanner-action@v1` does not exist.** Use `google/osv-scanner-action/osv-scanner-action@v1.8.5` (the real action lives in the `osv-scanner-action/` subdir). The OSV step only runs when dependency manifests exist (`hashFiles`); with none it's skipped — that's expected.
+- **github-script v7** already injects `context` and `github`; never redeclare `const { context } = …`. Comment-posting steps are guarded with `context.payload.pull_request?.number` so non-PR runs don't hit the API.
+- **Cross-job files don't persist on GitHub** (each job gets a fresh workspace). Each workflow that writes reports/records must upload them as run artifacts from the same job that wrote them; artifacts use `if: !github.event.pull_request` (or `real_deploy == 'false'`) guards.
+- **Workflows run on every PR synchronize** and each posts a comment — expect a comment per push on active PRs.
+- **`make sync` must be run before committing**: GitHub only executes workflows from `.github/workflows/`, and `make lint` fails on drift between the two trees.
+- **On Apple Silicon, nothing here needs a container**; `actionlint` runs natively via Homebrew.
+- **Trufflehog needs a base commit**: on non-PR runs use the empty-tree SHA `4b825dc642cb6eb9a060e54bf8d69288fbee4904` so the scan still covers the tree deterministically.
+- **Deployments default to dry-run**: `workflow_dispatch` on `release-pipeline` defaults `dry_run: true`; only a push to `main` or an explicit `dry_run: false` calls the Deployment API. `rollback_to` always records a dry-run rollback event.
+
+## Definition of done for workflow changes
+
+- Canonical workflow edited, then `make sync` and `make lint` green.
+- Non-PR (`workflow_dispatch`, push, schedule) paths guarded: comments only on PRs, artifacts uploaded for non-PR runs.
+- Verified natively on GitHub: `make test-gh` (PR loop) and/or a `workflow_dispatch` run.
+- Docs (`docs/architecture.md`, this guide, the ADR log) updated to match.
+
+See `docs/local-runbook.md` for the hands-on runbook and `docs/decisions/` for the design decisions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,97 @@
+# Delivery Engine — Architecture
+
+The delivery engine is the GitHub Actions setup under `.github/`. It implements the PDM (Product Delivery Management) delivery gates: shift-left security and compliance scanning, an aggregated quality gate, and a promotion pipeline across environments — all exercised natively on GitHub. "PDM" here means Product Delivery Management, **not** the Python package manager.
+
+The repo also carries a minimal Node 22 service (`package.json`, eslint, `node --test`, `scripts/build.mjs` producing `dist/`) so the quality gate and the release build have real work to do. Application code exists only to give the gates real work.
+
+## Layout: canonical vs mirrored
+
+- `.github/pdm/workflows/` — canonical workflow definitions, the source of truth.
+- `.github/workflows/` — byte-identical execution copies. GitHub only executes workflows from this directory.
+- `make sync` copies canonical workflows into `.github/workflows/`.
+- `make lint` runs actionlint on both trees **and** fails if the execution copies have drifted.
+
+Edit only `.github/pdm/workflows/`, run `make sync`, then `make lint`, and commit both sides together.
+
+Run artifacts (reports, deployment records, release notes) are written under `.github/pdm/{reports,deployments,releases}/` by workflows but are never committed — they are uploaded as run artifacts instead.
+
+## Workflow map
+
+| Workflow | Triggers | Jobs | Permissions | Outputs / artifacts |
+|---|---|---|---|---|
+| `risk-health-check.yml` | PR to `main` (opened / synchronize / reopened / ready_for_review); `workflow_dispatch` | `security` (gitleaks + OSV), `code-health` (npm lint/test), `risk-review` (AI-assisted diff risk review), `risk-report` (aggregate) | `contents: read`, `pull-requests: write` | PR comment on PR runs; `risk-report` artifact (`risk-report.md`) on non-PR runs |
+| `compliance-guardrail.yml` | PR to `main`; `workflow_dispatch` | `compliance-scan` (trufflehog base-to-head) | `contents: read`, `pull-requests: write` (job-level) | pass/fail PR comment on PR runs; no artifact on non-PR runs |
+| `quality-gate.yml` | PR to `main`; `workflow_dispatch` | `workflow-lint` (actionlint), `code-quality` (lint/test/build), `gate` (single aggregated conclusion) | `contents: read`, `pull-requests: write` | required status check on `main`; PR comment or `gate-report` artifact (non-PR) |
+| `release-pipeline.yml` | push to `main`; `workflow_dispatch` with `environment` (default `all`), `dry_run` (default `true`), `rollback_to` | `build`, `deploy-development`, `deploy-staging`, `deploy-production`, `rollback` | `contents: read`, `deployments: write` | `build-info` artifact; dry-run `deploy-record-<env>.md` / `rollback.md` artifacts; real `createDeployment` calls when not dry-run |
+| `security-rescan.yml` | weekly schedule (Mon 02:00 UTC); `workflow_dispatch` | `gitleaks`, `osv`, `report` | `contents: read`, `issues: write` | `security-rescan-report` artifact; issue filed on blocking gitleaks findings on schedule runs |
+| `release-on-tag.yml` | push tags `v*` | `release` (build, release notes, GitHub Release) | `contents: write` | GitHub Release + `release-notes` artifact |
+
+Adjacent configuration: `.github/dependabot.yml` keeps GitHub Actions and npm dependencies fresh (weekly, targeting `develop`).
+
+## PR-gate pipeline
+
+Three workflows gate every PR to `main`; `quality-gate` is the single required status check, so nothing merges unless all three pass:
+
+```
+                        PR to main
+                             │
+        ┌────────────────────┼────────────────────┐
+        ▼                    ▼                    ▼
+risk-health-check    compliance-guardrail   quality-gate (required)
+gitleaks + OSV +     trufflehog base..head  actionlint + lint/test/build
+code-health + AI     posts pass/fail        single aggregated conclusion
+diff risk review;    PR comment             = required status check
+posts report comment
+        │                    │                    │
+        └────────────────────┼────────────────────┘
+                             ▼
+                       merge to main
+                             │
+                             ▼
+                    release-pipeline
+        build → development → staging → production
+       (dry-run by default; approval required on staging/production)
+```
+
+On PR runs the workflows post comments; on non-PR (`workflow_dispatch`) runs they upload reports and dry-run deployment records as run artifacts instead.
+
+## Promotion chain
+
+```
+push to main (or workflow_dispatch)
+        │
+        ▼
+     build ──► build-info artifact
+        │
+        ▼
+deploy-development   (no approval)
+        │
+        ▼
+deploy-staging       (approval via required_reviewers)
+        │
+        ▼
+deploy-production    (approval via required_reviewers)
+```
+
+- The GitHub environments `development` / `staging` / `production` exist; `staging` and `production` have a `required_reviewers` protection rule.
+- `environment` input selects the chain: `development` (dev only), `staging` (staging, then production), `production` (production only), `all` (full chain, default).
+- A push to `main` is always a real deployment (`real_deploy=true`, calls `createDeployment`). A `workflow_dispatch` run defaults to `dry_run: true`, which writes `deploy-<env>.md` records and uploads them as artifacts without touching the Deployment API.
+- Each environment job runs a post-deploy verify step: if `DEPLOY_VERIFY_URL` is set it curls the URL (failing the job on a non-200 response); otherwise verification is skipped.
+- `rollback_to` records a dry-run rollback event (`rollback.md`, uploaded as `rollback-record` artifact) — no API call, useful for planning and audit.
+
+## Release on tag and security re-scan
+
+- `release-on-tag.yml` triggers on `v*` tags: builds the deployable, generates release notes (commits since the previous tag, or the most recent commits when no previous tag exists), creates a GitHub Release, and uploads the release notes as an artifact.
+- `security-rescan.yml` runs weekly plus on demand: gitleaks + OSV across the whole repo, then a report job writes `security-rescan-<date>.md` and uploads it as an artifact. On schedule runs, a blocking gitleaks failure also opens an issue; `workflow_dispatch` runs do not.
+
+## Testing model (GitHub native)
+
+Workflows are verified by running them on GitHub — there is no local `act`/Docker harness. The loop is:
+
+1. Edit only `.github/pdm/workflows/`, then `make sync` and `make lint`.
+2. Open a PR to `main` — the three PR workflows run natively and post comments. `make test-gh` automates this: it pushes the current branch, opens (or updates) a PR to `main`, and watches `gh pr checks`.
+3. For the release pipeline, use `workflow_dispatch` (default `dry_run: true`); on non-PR runs results are uploaded as run artifacts, downloadable from the run's "Artifacts" section.
+
+Requires the `gh` CLI (`gh auth login`) and push access; `actionlint` runs natively via Homebrew on Apple Silicon.
+
+See `docs/ROADMAP.md` for the phase breakdown, `docs/local-runbook.md` for the hands-on runbook, `docs/agents-guide.md` for contributor and agent guidance, and `docs/decisions/` for the design decisions that shaped this engine.

--- a/docs/decisions/0001-empty-tree-base-sha.md
+++ b/docs/decisions/0001-empty-tree-base-sha.md
@@ -1,0 +1,23 @@
+# ADR 0001: Empty-tree base SHA for trufflehog
+
+- **Status:** Accepted
+
+## Context
+
+`compliance-guardrail` runs trufflehog against a diff of the PR (`base` to `head`) so only changed code is scanned for secrets and compliance violations. On PR runs the base is `github.event.pull_request.base.sha`. On non-PR runs (`workflow_dispatch`) there is no PR payload, so `base.sha` is empty and the scan would have no well-defined range.
+
+## Decision
+
+Default the base to the Git empty-tree object SHA:
+
+```yaml
+base: ${{ github.event.pull_request.base.sha || '4b825dc642cb6eb9a060e54bf8d69288fbee4904' }}
+```
+
+On non-PR runs the scan covers everything since the empty tree — effectively the whole repository.
+
+## Consequences
+
+- Non-PR runs get a deterministic, whole-tree scan instead of a broken or empty diff.
+- The magic SHA must stay in sync wherever it is referenced (the workflow and this ADR).
+- PR runs are unaffected: the base SHA is always present.

--- a/docs/decisions/0002-dry-run-default-release-pipeline.md
+++ b/docs/decisions/0002-dry-run-default-release-pipeline.md
@@ -1,0 +1,27 @@
+# ADR 0002: Dry-run default in the release pipeline
+
+- **Status:** Accepted
+
+## Context
+
+`release-pipeline` can call the GitHub Deployment API (`createDeployment`) and create real deployment records. Pushes to `main` are the production path, but the pipeline is also run manually via `workflow_dispatch` for testing and rehearsals. Without a guard, every manual run would create noisy deployment records.
+
+## Decision
+
+The `workflow_dispatch` input `dry_run` defaults to `true`. The build job resolves the mode:
+
+```yaml
+if [[ "${{ github.event_name }}" == "push" || "${{ inputs.dry_run }}" == "false" ]]; then
+  echo "real=true"
+else
+  echo "real=false"
+fi
+```
+
+In dry-run mode each environment job writes a `deploy-<env>.md` record under `.github/pdm/deployments/` and uploads it as an artifact instead of calling the Deployment API. A push to `main`, or an explicit `dry_run: false`, triggers real deployments. `rollback_to` always records a dry-run rollback event.
+
+## Consequences
+
+- Manual runs are safe by default — real deployments require an explicit opt-out.
+- The same workflow supports rehearsal (artifacts) and real promotion (Deployment API).
+- Records confirm what would have happened, for audit and rollback planning.

--- a/docs/decisions/0003-canonical-synced-workflow-copies.md
+++ b/docs/decisions/0003-canonical-synced-workflow-copies.md
@@ -1,0 +1,24 @@
+# ADR 0003: Canonical and mirrored workflow copies
+
+- **Status:** Accepted
+
+## Context
+
+GitHub only executes workflows from `.github/workflows/`. Keeping the workflows there directly made them hard to reason about as a single "engine" deliverable and left no drift detection.
+
+## Decision
+
+Canonical workflow definitions live in `.github/pdm/workflows/` (the source of truth). `make sync` copies them byte-identical into `.github/workflows/`. `make lint` runs actionlint on both trees and fails if the two trees differ.
+
+```
+make sync   # cp .github/pdm/workflows/*.yml → .github/workflows/
+make lint   # actionlint on both trees + diff -r drift check
+```
+
+Edit only `.github/pdm/workflows/` and commit both sides after syncing.
+
+## Consequences
+
+- One source of truth; contributors never edit the execution copies directly.
+- Drift is caught by `make lint` before it reaches a PR.
+- A forgotten `make sync` fails loudly rather than silently executing stale workflows.

--- a/docs/decisions/0004-run-artifact-persistence.md
+++ b/docs/decisions/0004-run-artifact-persistence.md
@@ -1,0 +1,18 @@
+# ADR 0004: Persist reports and records as run artifacts
+
+- **Status:** Accepted (replaces the earlier `--bind` volume-mount approach)
+
+## Context
+
+Cross-job files do not persist on GitHub Actions — each job gets a fresh workspace. Earlier iterations of the repo used a local `act`/Docker harness where a `--bind` volume mount let workflows write reports and deployment records straight into the working directory. With the move to GitHub-native testing (see ADR 0007), there is no shared filesystem, so results written inside a job workspace would be lost when the job ends.
+
+## Decision
+
+Workflows that produce reports or deployment records write them inside the job workspace (`.github/pdm/reports/`, `.github/pdm/deployments/`) and upload them with `actions/upload-artifact@v4` from the same job that wrote them. Uploads are guarded so only non-PR runs persist artifacts (`if: github.event.pull_request.number == null` for reports, `if: needs.build.outputs.real_deploy == 'false'` for dry-run deployment records). PR runs surface the same content as comments instead (see ADR 0005). The output directories are gitignored — artifacts are per-run, never committed.
+
+## Consequences
+
+- Reports and records are downloadable from the run's "Artifacts" section for non-PR runs.
+- No shared volumes or persistent storage are needed; each job owns its upload.
+- Content that matters for PR review is delivered as comments on the PR instead.
+- Any workflow that writes a report/record must upload it from the same job — a hard-won cross-job constraint.

--- a/docs/decisions/0005-comment-guard-pull-request-number.md
+++ b/docs/decisions/0005-comment-guard-pull-request-number.md
@@ -1,0 +1,22 @@
+# ADR 0005: Guard PR comments with the pull request number
+
+- **Status:** Accepted
+
+## Context
+
+Report and gate workflows post results as PR comments using `actions/github-script@v7`. Workflows also run on non-PR events (`workflow_dispatch`, push, schedule) where there is no pull request to comment on — an unguarded comment step would call the issues API with no issue and fail the run.
+
+## Decision
+
+Comment-posting steps are guarded by the pull request number:
+
+- In YAML: `if: github.event.pull_request.number != null` (used by `risk-health-check` and `quality-gate`).
+- In github-script: `if (context.payload.pull_request?.number) { ... }` (used by `compliance-guardrail`).
+
+Additionally, github-script v7 already injects `context` and `github` — never redeclare `const { context } = ...`. Non-PR runs persist their output as run artifacts instead of commenting (ADR 0004).
+
+## Consequences
+
+- Non-PR runs never touch the comments API, so they cannot fail on a missing PR.
+- One code path serves both PR and non-PR events: comment when a PR exists, artifact otherwise.
+- Reviewers see results inline on PRs; manual/scheduled runs get artifacts.

--- a/docs/decisions/0006-osv-scanner-action-subdirectory-path.md
+++ b/docs/decisions/0006-osv-scanner-action-subdirectory-path.md
@@ -1,0 +1,23 @@
+# ADR 0006: osv-scanner-action resolves under a subdirectory path
+
+- **Status:** Accepted
+
+## Context
+
+The vulnerability scan in `risk-health-check` and `security-rescan` targets `osv-scanner-action`. Referencing it as `osv-scanner-action@v1` fails — no such action short name exists at the top level of the Google OSV repository; the real action lives in the `osv-scanner-action/` subdirectory.
+
+## Decision
+
+Use the full subdirectory path with an explicit pinned version:
+
+```yaml
+uses: google/osv-scanner-action/osv-scanner-action@v1.8.5
+```
+
+The OSV step is additionally gated by `hashFiles(...)` over common lockfiles and manifests; when none exist the step is skipped (a separate step prints a "skipped" notice). That is expected behavior, not a failure.
+
+## Consequences
+
+- The action resolves and versions correctly across GitHub-native runs.
+- Repos without dependency manifests skip the scan by design.
+- The pinned version keeps the supply-chain surface explicit; bump deliberately.

--- a/docs/decisions/0007-github-native-over-act.md
+++ b/docs/decisions/0007-github-native-over-act.md
@@ -1,0 +1,22 @@
+# ADR 0007: Test workflows natively on GitHub over a local act harness
+
+- **Status:** Accepted
+
+## Context
+
+Phase 0/1 originally proved the delivery engine locally with an `act`/Docker harness: `.act/` fixture files, a token, and container bind-mounts. That harness drifted from real GitHub behavior (expression evaluation, concurrency groups, environment protection, job artifacts), needed Docker to be started on every run, and on Apple Silicon nothing required a container.
+
+## Decision
+
+Remove the `act` harness and Dockerfile. Workflows are verified by running them on GitHub:
+
+- Push a branch and open a PR to `main` — the three PR gates execute natively and post comments (`make test-gh` automates the push + PR + `gh pr checks --watch` loop).
+- Exercise the release pipeline via `workflow_dispatch` (default `dry_run: true`), with reports and dry-run deployment records uploaded as run artifacts.
+- Keep `actionlint` for fast static validation of workflow syntax and expressions, run natively via Homebrew.
+
+## Consequences
+
+- Runs are authoritative — they behave exactly as production GitHub would.
+- Feedback loop is one push plus a PR; no Docker or fixture files to maintain.
+- Non-PR results (reports, deployment records) are captured as run artifacts (ADR 0004), and PR review feedback lands as comments (ADR 0005).
+- Requires `gh` CLI access and push access to the repository.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,15 @@
+# Decision Log
+
+Architecture Decision Records (ADRs) for the PDM delivery engine. Each entry records a decision, the context that motivated it, and its consequences. New decisions follow the same format as `NNNN-slug.md`.
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](0001-empty-tree-base-sha.md) | Empty-tree base SHA for trufflehog | Accepted |
+| [0002](0002-dry-run-default-release-pipeline.md) | Dry-run default in the release pipeline | Accepted |
+| [0003](0003-canonical-synced-workflow-copies.md) | Canonical and mirrored workflow copies | Accepted |
+| [0004](0004-run-artifact-persistence.md) | Persist reports and records as run artifacts | Accepted |
+| [0005](0005-comment-guard-pull-request-number.md) | Guard PR comments with the pull request number | Accepted |
+| [0006](0006-osv-scanner-action-subdirectory-path.md) | osv-scanner-action resolves under a subdirectory path | Accepted |
+| [0007](0007-github-native-over-act.md) | Test workflows natively on GitHub over a local act harness | Accepted |
+
+Superseded or rejected decisions are removed from the index but the record itself may note the supersession (see [0004](0004-run-artifact-persistence.md)).

--- a/docs/local-runbook.md
+++ b/docs/local-runbook.md
@@ -1,0 +1,80 @@
+# Native Runbook — testing the delivery engine on GitHub
+
+Workflows are verified by running them on GitHub: open a PR and the PR gates execute natively; run the release pipeline via `workflow_dispatch`. There is no local `act`/Docker harness — nothing here needs a container (on Apple Silicon `actionlint` runs natively via Homebrew).
+
+Prerequisites: `gh` CLI (`gh auth login`), actionlint (`brew install actionlint`), and push access to the repo.
+
+## Workflow editing loop
+
+Edit **only** `.github/pdm/workflows/`. GitHub only executes workflows from `.github/workflows/`, so mirror and validate every change:
+
+```sh
+make sync   # copy canonical workflows to .github/workflows/ (byte-identical)
+make lint   # actionlint on canonical + execution copies, then drift check
+```
+
+Commit both trees together. `make lint` exits non-zero on drift.
+
+## `make test-gh` — the PR verification loop
+
+`make test-gh` does three things:
+
+1. Pushes the current branch to `origin`.
+2. Opens a PR to `main` (title `PDM workflow run (<branch>)`), or updates the existing PR for that branch.
+3. Watches the checks with `gh pr checks --watch` (Ctrl-C stops the watch; the checks keep running).
+
+Opening that PR triggers the three PR workflows natively:
+
+- `risk-health-check` — gitleaks, OSV (skipped when no dependency manifests), npm lint/test, AI-assisted diff risk review, then a report comment.
+- `compliance-guardrail` — trufflehog base-to-head, posts a pass/fail comment.
+- `quality-gate` — actionlint + lint/test/build aggregated into a single gate. This is the **required status check** on `main`, so it also gates mergeability.
+
+Expect one comment per push on active PRs (workflows run on every `synchronize`).
+
+## `workflow_dispatch` — the release pipeline
+
+Exercise the release pipeline without pushing to `main`:
+
+```sh
+gh workflow run release-pipeline.yml --ref <branch> --field environment=all --field dry_run=true
+```
+
+Inputs:
+
+- `environment` — `all` (default), `development`, `staging`, or `production`. `staging` promotes staging then production; `production` deploys production only.
+- `dry_run` — default `true`. `false` (or a push to `main`) calls the GitHub Deployment API (`createDeployment`).
+- `rollback_to` — optional commit SHA. Records a dry-run rollback event (no API call).
+
+Environment behavior:
+
+- `development` deploys without approval.
+- `staging` and `production` require review approval (`required_reviewers` protection rule) — approve in the run UI.
+- Each environment job verifies the deploy by curling `DEPLOY_VERIFY_URL` if the variable is set; otherwise verification is skipped.
+
+Scheduled and tag workflows:
+
+- `security-rescan` runs weekly (Mon 02:00 UTC) and on demand via `workflow_dispatch`; on schedule runs a blocking gitleaks failure opens an issue.
+- `release-on-tag` fires on `v*` tags and creates a GitHub Release with generated release notes.
+
+## Where results land
+
+| Event | Results |
+|---|---|
+| PR run | PR comments (risk report, compliance pass/fail, gate summary) |
+| Non-PR run (`workflow_dispatch`, push, schedule) | Run artifacts: `risk-report`, `gate-report`, `security-rescan-report`, `deploy-record-<env>`, `rollback-record`, `release-notes`, `build-info` — download from the run's "Artifacts" section |
+| Dry-run release | `deploy-<env>.md` records written under `.github/pdm/deployments/` in the job workspace, uploaded as artifacts (never committed) |
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+|---|---|
+| `make lint` fails with `DRIFT: .github/workflows/ differs from .github/pdm/workflows/` | You edited the canonical tree without re-syncing. Run `make sync` and commit both sides. |
+| `actionlint: command not found` | actionlint is not installed. `brew install actionlint` (native on Apple Silicon). |
+| OSV step shows as skipped in `risk-health-check` / `security-rescan` | Expected — the scan only runs when dependency manifests exist (`hashFiles`); with none it is skipped. |
+| No PR comment posted on a `workflow_dispatch` run | Expected — comments are guarded by the pull request number; non-PR runs upload artifacts instead. |
+| Quality gate not showing as a required check | Branch protection on `main` must require the `PDM Quality Gate (Status Check)` check. |
+| Staging/production deploy waiting indefinitely | Environment protection requires a reviewer — approve the run in the Actions UI. |
+| `gh: not authenticated` | Run `gh auth login`. |
+| `make test-gh` errors on push | Push access is required; check your remote and branch protection. |
+| Dry-run release produced no Deployment API records | Expected — `dry_run: true` (default) skips `createDeployment` and writes `deploy-<env>.md` artifacts instead. |
+| One comment per push on an active PR | Expected — the PR workflows re-run on every `synchronize`. |


### PR DESCRIPTION
Ports the Phase 5 docs track onto current develop, rewritten for the GitHub-native engine.

- docs/architecture.md — workflow map (all six workflows), PR-gate pipeline diagram, promotion chain
- docs/local-runbook.md — GitHub-native runbook (make sync/lint/test-gh, workflow_dispatch, artifacts, troubleshooting)
- docs/agents-guide.md — tracked contributor/agent guide promoting AGENTS.md gotchas
- docs/decisions/ — ADR log (0001-0007, incl. run-artifact persistence replacing --bind and GitHub-native-over-act)
- Doc-pointer headers on compliance-guardrail + quality-gate
- README Documentation Shortcuts section

`make lint` green; no drift.