### PR TITLE
fix(ci): sync dependabot version bumps into canonical workflows

### DIFF
--- a/.github/pdm/workflows/compliance-guardrail.yml
+++ b/.github/pdm/workflows/compliance-guardrail.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install actionlint
         shell: bash
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Detect Node.js toolchain
         id: detect
@@ -77,7 +77,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/pdm/workflows/release-on-tag.yml
+++ b/.github/pdm/workflows/release-on-tag.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/pdm/workflows/release-pipeline.yml
+++ b/.github/pdm/workflows/release-pipeline.yml
@@ -45,7 +45,7 @@ jobs:
       real_deploy: ${{ steps.mode.outputs.real }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Detect application stack
         id: stack
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -257,7 +257,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download build artifact
         uses: actions/download-artifact@v4
@@ -324,7 +324,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Record rollback event
         shell: bash

--- a/.github/pdm/workflows/risk-health-check.yml
+++ b/.github/pdm/workflows/risk-health-check.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Detect Node.js toolchain
         id: detect
@@ -89,7 +89,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm
@@ -118,12 +118,12 @@ jobs:
       risk_summary: ${{ steps.review.outputs.risk_summary }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -178,7 +178,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Build health summary
         id: summary

--- a/.github/pdm/workflows/security-rescan.yml
+++ b/.github/pdm/workflows/security-rescan.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Secret scan (gitleaks)
         uses: gitleaks/gitleaks-action@v3
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Vulnerability scan (OSV)
         if: hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml', '**/requirements*.txt', '**/poetry.lock', '**/Pipfile.lock', '**/Cargo.lock', '**/go.sum', '**/Gemfile.lock', '**/composer.lock', '**/pom.xml', '**/build.gradle*') != ''
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Write re-scan report
         shell: bash


### PR DESCRIPTION
Dependabot (T4.3) bumped only the `.github/workflows/` execution copies to `checkout@v7` / `setup-node@v7`, leaving `.github/pdm/workflows/` at older pins — violating the canonical mirror discipline and failing `make lint`.

This syncs the canonical tree to the merged dependency versions and re-mirrors. `make lint` (actionlint + drift check) green.