### PR TITLE
fix(ci): adopt dependabot version bumps into canonical workflows

### DIFF
--- a/.github/pdm/workflows/compliance-guardrail.yml
+++ b/.github/pdm/workflows/compliance-guardrail.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Post Compliance Status
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const outcome = "${{ job.status }}";

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Post gate summary comment
         if: github.event.pull_request.number != null
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/pdm/workflows/release-on-tag.yml
+++ b/.github/pdm/workflows/release-on-tag.yml
@@ -78,7 +78,7 @@ jobs:
           echo "Wrote ${notes_file}"
 
       - name: Create GitHub Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const tag = context.ref.replace('refs/tags/', '');

--- a/.github/pdm/workflows/release-pipeline.yml
+++ b/.github/pdm/workflows/release-pipeline.yml
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-info
           path: dist
@@ -144,7 +144,7 @@ jobs:
       - name: Record development deployment
         env:
           ENV_NAME: development
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const envName = process.env.ENV_NAME;
@@ -190,7 +190,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-info
           path: dist
@@ -214,7 +214,7 @@ jobs:
       - name: Record staging deployment
         env:
           ENV_NAME: staging
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const envName = process.env.ENV_NAME;
@@ -260,7 +260,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-info
           path: dist
@@ -284,7 +284,7 @@ jobs:
       - name: Record production deployment
         env:
           ENV_NAME: production
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const envName = process.env.ENV_NAME;

--- a/.github/pdm/workflows/risk-health-check.yml
+++ b/.github/pdm/workflows/risk-health-check.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Vulnerability scan (OSV)
         if: hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml', '**/requirements*.txt', '**/poetry.lock', '**/Pipfile.lock', '**/Cargo.lock', '**/go.sum', '**/Gemfile.lock', '**/composer.lock', '**/pom.xml', '**/build.gradle*') != ''
-        uses: google/osv-scanner-action/osv-scanner-action@v1.8.5
+        uses: google/osv-scanner-action/osv-scanner-action@v2.5.0
         with:
           scan-args: |-
             -r=.
@@ -197,7 +197,7 @@ jobs:
 
       - name: Post risk report comment
         if: github.event.pull_request.number != null
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/pdm/workflows/security-rescan.yml
+++ b/.github/pdm/workflows/security-rescan.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Vulnerability scan (OSV)
         if: hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml', '**/requirements*.txt', '**/poetry.lock', '**/Pipfile.lock', '**/Cargo.lock', '**/go.sum', '**/Gemfile.lock', '**/composer.lock', '**/pom.xml', '**/build.gradle*') != ''
-        uses: google/osv-scanner-action/osv-scanner-action@v1.8.5
+        uses: google/osv-scanner-action/osv-scanner-action@v2.5.0
         with:
           scan-args: |-
             -r=.
@@ -85,7 +85,7 @@ jobs:
 
       - name: Open issue on blocking secret findings
         if: needs.gitleaks.result == 'failure' && github.event_name != 'workflow_dispatch'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.create({

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,22 @@
 PDM_WF    := .github/pdm/workflows
 GH_WF     := .github/workflows
 
-.PHONY: lint sync test-gh
+.PHONY: lint sync sync-deps test-gh
 
 # Mirror canonical workflows into .github/workflows (GitHub only executes there)
 sync:
 	@mkdir -p $(GH_WF)
 	@cp $(PDM_WF)/*.yml $(GH_WF)/
 	@echo "Synced $(PDM_WF) -> $(GH_WF)"
+
+# Adopt dependency-version bumps into the canonical tree. Dependabot only scans
+# .github/workflows/ (standard GitHub Actions location), so after a dependabot
+# merge run this to copy the bumped execution copies back into canonical, then
+# 'make sync' to re-mirror. Run 'make lint' to confirm no drift.
+sync-deps:
+	@mkdir -p $(PDM_WF)
+	@cp $(GH_WF)/*.yml $(PDM_WF)/
+	@echo "Adopted $(GH_WF) version bumps into $(PDM_WF); run 'make sync' to re-mirror."
 
 # Validate workflow YAML syntax + expressions (no Docker required),
 # and fail if the GitHub execution copies have drifted from canonical.


### PR DESCRIPTION
Dependabot only scans `.github/workflows/` (the standard GitHub Actions location) and never touches the canonical tree in `.github/pdm/workflows/`, so each dependabot merge re-introduced drift that failed `make lint`.

This adds a `make sync-deps` target (mirrors the bumped execution copies back into canonical) and applies it to adopt the merged bumps (checkout/setup-node v7, download-artifact v8, github-script v9, osv-scanner-action v2.5.0) across all six workflows. `make lint` green, no drift.