### PR TITLE
Phase 7: delivery telemetry & audit trail

### DIFF
--- a/.github/pdm/workflows/delivery-telemetry.yml
+++ b/.github/pdm/workflows/delivery-telemetry.yml
@@ -1,0 +1,48 @@
+name: PDM Delivery Telemetry & Audit Trail
+
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# Reads GitHub-native delivery records via the API and exports the audit trail +
+# DORA-style telemetry as run artifacts (never committed).
+
+on:
+  schedule:
+    - cron: '30 2 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: delivery-telemetry
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  telemetry:
+    name: Collect delivery telemetry & audit trail
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Run delivery telemetry & audit trail exporter
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOOKBACK_DAYS: '90'
+        run: |
+          mkdir -p .github/pdm/reports
+          node scripts/delivery-telemetry.mjs .github/pdm/reports
+          ls -la .github/pdm/reports/delivery-*
+
+      - name: Upload delivery telemetry & audit trail
+        uses: actions/upload-artifact@v4
+        with:
+          name: delivery-telemetry
+          path: .github/pdm/reports/delivery-*
+          retention-days: 7

--- a/.github/workflows/delivery-telemetry.yml
+++ b/.github/workflows/delivery-telemetry.yml
@@ -1,0 +1,48 @@
+name: PDM Delivery Telemetry & Audit Trail
+
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# Reads GitHub-native delivery records via the API and exports the audit trail +
+# DORA-style telemetry as run artifacts (never committed).
+
+on:
+  schedule:
+    - cron: '30 2 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: delivery-telemetry
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  telemetry:
+    name: Collect delivery telemetry & audit trail
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Run delivery telemetry & audit trail exporter
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOOKBACK_DAYS: '90'
+        run: |
+          mkdir -p .github/pdm/reports
+          node scripts/delivery-telemetry.mjs .github/pdm/reports
+          ls -la .github/pdm/reports/delivery-*
+
+      - name: Upload delivery telemetry & audit trail
+        uses: actions/upload-artifact@v4
+        with:
+          name: delivery-telemetry
+          path: .github/pdm/reports/delivery-*
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ All PDM workflow and deployment material is consolidated under a single folder, 
   - `compliance-guardrail.yml` - Enforces shift-left security scans and secret detection before code merges.
   - `quality-gate.yml` - Required status check: actionlint on workflows + toolchain-driven lint/test/build, aggregated into a single branch-protection gate.
   - `release-pipeline.yml` - Promotes builds through development/staging/production environments and records dry-run deployments.
+  - `delivery-telemetry.yml` - Exports the GitHub-native delivery audit trail and DORA-style telemetry as run artifacts (weekly + on demand).
 - `.github/pdm/deployments/` - Dry-run deployment records uploaded as run artifacts by the release pipeline (not committed).
 - `.github/pdm/reports/` - Risk and quality-gate reports uploaded as run artifacts (not committed).
 - `.github/workflows/` - Mirrored execution copies of `.github/pdm/workflows/`. GitHub only executes workflows from this directory, so keep the copies in sync with `make sync`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,15 +131,15 @@ Phases 2–5 are **independent tracks** — each is planned/executed as its own 
 - **T7.2** `delivery-telemetry.yml` — weekly schedule (Mon 02:30 UTC) + `workflow_dispatch`; runs the exporter with the built-in `GITHUB_TOKEN` and uploads `delivery-telemetry` (audit JSON + metrics JSON + markdown report) as a run artifact. ✅ done — `.github/pdm/workflows/delivery-telemetry.yml` + synced copy
 - **T7.3** ADR 0008 records the decision to compute telemetry from GitHub-native records over an external observability tool. ✅ done — `docs/decisions/0008-github-native-delivery-telemetry.md`
 - **T7.4** Docs updated: architecture workflow map + telemetry section, runbook results table, agent guide. ✅ done
-- **T7.5** Verify natively on GitHub: `workflow_dispatch` run (and the weekly schedule) uploads the telemetry artifact. ⏳ pending — runs through the PR/`workflow_dispatch` loop, then this line flips to ✅
+- **T7.5** Verify natively on GitHub: the three PR gates passed on the `main` verification PR (which actionlint-validated the new workflow too). The `delivery-telemetry` `workflow_dispatch` run itself can only execute once the workflow file exists on `main` (GitHub registers dispatch workflows from the default branch) — so artifact-upload verification lands when the phase reaches `main`: `gh workflow run delivery-telemetry.yml --ref develop`. ⏳ pending land-on-main → flips to ✅
 
-**Acceptance:** `make lint` green; exporter tested against the live repo API; telemetry/audit artifacts upload on a native run.
+**Acceptance:** `make lint` green; exporter tested against the live repo API; PR gates green on the `main` verification PR; telemetry/audit artifacts upload once the workflow is dispatchable from `main`.
 
 ## 12. Execution Model
 
 Each phase is a **branch off `develop` + PR**, following the existing repo flow. Phases 2–5 run as parallel tracks after Phase 1 merges green. Phase 5 can start immediately and absorb notes from other tracks.
 
-> **Status:** Phases 0–6 complete. Track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main`. Phase 7 (delivery telemetry & audit trail) is implemented on `feat/phase7-delivery-telemetry`; native verification (T7.5) is the remaining step before it is marked complete.
+> **Status:** Phases 0–6 complete. Track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main`. Phase 7 (delivery telemetry & audit trail) is implemented on `feat/phase7-delivery-telemetry` and green against the PR gates; the dispatch-based artifact check (T7.5) finishes once the workflow reaches `main`.
 
 ## 13. Definition of Done (every phase)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,13 +6,14 @@ Turn this reference repo from a **harness + placeholders** into a **real, exerci
 
 ## 2. Current State
 
-- **6 canonical workflows** in `.github/pdm/workflows/`, byte-identical copies in `.github/workflows/` (currently in sync). `make lint` enforces no drift.
+- **7 canonical workflows** in `.github/pdm/workflows/`, byte-identical copies in `.github/workflows/` (currently in sync). `make lint` enforces no drift.
   - `risk-health-check` — gitleaks + osv-scanner + code-health + AI-assisted diff risk review (`scripts/risk-review.mjs`); posts PR comment or uploads a report artifact on non-PR runs
   - `compliance-guardrail` — trufflehog base→head; posts PR comment
   - `quality-gate` — actionlint + frontend lint/typecheck/test/build; gate job; required status check on `main`; posts comment / uploads report artifact
   - `release-pipeline` — build-info artifact; post-deploy verify; dry-run dev→staging→prod; rollback record; uploads deployment records on dry-run
   - `security-rescan` — scheduled (weekly) + `workflow_dispatch` gitleaks + osv; uploads report artifact; files an issue on blocking findings
   - `release-on-tag` — `v*` tag push; builds, generates release notes, creates a GitHub Release
+  - `delivery-telemetry` — weekly + on-demand export of the GitHub-native audit trail and DORA-style telemetry as run artifacts
 - **Application stack**: a Next.js 16 frontend (`frontend/`, TypeScript + Tailwind v4 + Vitest, pnpm) that the quality gate, code-health, and release build exercise (Phase 6 replaced the earlier minimal Node service).
 - **Frontend tooling**: native `make test-frontend` (install + lint + typecheck + test + build) — no container; CI runs the same suite via `corepack`/`pnpm` in `frontend/`.
 - **Testing is GitHub native**: workflows are verified by pushing a branch and opening a PR (`make test-gh`), plus `workflow_dispatch` runs for the release pipeline. No local `act`/Docker harness.
@@ -122,13 +123,25 @@ Phases 2–5 are **independent tracks** — each is planned/executed as its own 
 
 **Acceptance:** `make test-frontend` green, `make sync`/`make lint` clean, GitHub-native PR run green. ✅
 
-## 11. Execution Model
+## 11. Phase 7 — Delivery Telemetry & Audit Trail
+
+**Goal:** make delivery outcomes observable. Every delivery event is already recorded natively by GitHub (Deployment API records, releases, merged PRs, issues); Phase 7 reads that record and turns it into a durable audit trail plus DORA-style telemetry, with no external observability service.
+
+- **T7.1** `scripts/delivery-telemetry.mjs` — exports a raw audit-trail snapshot (deployments per environment, releases, merged PRs, rollback/incident issues) and derives deployment frequency, lead time for changes, change failure rate, and a time-to-recovery proxy. Insufficient data is reported as `insufficient-data` and explained, never invented. ✅ done — `scripts/delivery-telemetry.mjs`
+- **T7.2** `delivery-telemetry.yml` — weekly schedule (Mon 02:30 UTC) + `workflow_dispatch`; runs the exporter with the built-in `GITHUB_TOKEN` and uploads `delivery-telemetry` (audit JSON + metrics JSON + markdown report) as a run artifact. ✅ done — `.github/pdm/workflows/delivery-telemetry.yml` + synced copy
+- **T7.3** ADR 0008 records the decision to compute telemetry from GitHub-native records over an external observability tool. ✅ done — `docs/decisions/0008-github-native-delivery-telemetry.md`
+- **T7.4** Docs updated: architecture workflow map + telemetry section, runbook results table, agent guide. ✅ done
+- **T7.5** Verify natively on GitHub: `workflow_dispatch` run (and the weekly schedule) uploads the telemetry artifact. ⏳ pending — runs through the PR/`workflow_dispatch` loop, then this line flips to ✅
+
+**Acceptance:** `make lint` green; exporter tested against the live repo API; telemetry/audit artifacts upload on a native run.
+
+## 12. Execution Model
 
 Each phase is a **branch off `develop` + PR**, following the existing repo flow. Phases 2–5 run as parallel tracks after Phase 1 merges green. Phase 5 can start immediately and absorb notes from other tracks.
 
-> **Status:** Phases 0–6 complete. Track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main`. Phase 7 (delivery telemetry & audit trail) is the next track.
+> **Status:** Phases 0–6 complete. Track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main`. Phase 7 (delivery telemetry & audit trail) is implemented on `feat/phase7-delivery-telemetry`; native verification (T7.5) is the remaining step before it is marked complete.
 
-## 12. Definition of Done (every phase)
+## 13. Definition of Done (every phase)
 
 - `make lint` green (no drift) after every change.
 - All affected workflows verified green via GitHub-native runs (PR + `workflow_dispatch`).

--- a/docs/agents-guide.md
+++ b/docs/agents-guide.md
@@ -13,7 +13,7 @@ The engine is the GitHub Actions setup under `.github/`. Application code (a Nex
 - `.github/pdm/workflows/` — canonical workflow definitions (source of truth).
 - `.github/workflows/` — GitHub-only execution copies, kept byte-identical via `make sync`.
 - `.github/pdm/{reports,deployments,releases}/` — run-artifact staging dirs written by workflows; never committed.
-- `scripts/` — Node helpers used by workflows (`risk-review.mjs`).
+- `scripts/` — Node helpers used by workflows (`risk-review.mjs`, `delivery-telemetry.mjs`).
 - `frontend/` — the Next.js application the delivery gates exercise (pnpm-managed).
 - `docs/` — architecture, native runbook, agent guide, ROADMAP, and the ADR decision log.
 - `Makefile` — `sync`, `lint`, `test-frontend`, `test-gh` targets.
@@ -43,6 +43,7 @@ Edit only `.github/pdm/workflows/` and re-sync. Open a PR to `main` and GitHub r
 - **On Apple Silicon, nothing here needs a container**; `actionlint` runs natively via Homebrew.
 - **Trufflehog needs a base commit**: on non-PR runs use the empty-tree SHA `4b825dc642cb6eb9a060e54bf8d69288fbee4904` so the scan still covers the tree deterministically.
 - **Deployments default to dry-run**: `workflow_dispatch` on `release-pipeline` defaults `dry_run: true`; only a push to `main` or an explicit `dry_run: false` calls the Deployment API. `rollback_to` always records a dry-run rollback event.
+- **Delivery telemetry reads GitHub-native records only** (ADR 0008): `scripts/delivery-telemetry.mjs` queries the Deployments/Releases/Pulls/Issues APIs with the built-in `GITHUB_TOKEN` and exports audit + metrics as run artifacts. Dry-run records are artifacts, not API events, so they never populate the metrics — expect `insufficient-data` until real deployments and rollback/incident issues exist.
 
 ## Definition of done for workflow changes
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ Run artifacts (reports, deployment records, release notes) are written under `.g
 | `release-pipeline.yml` | push to `main`; `workflow_dispatch` with `environment` (default `all`), `dry_run` (default `true`), `rollback_to` | `build` (frontend `next build`), `deploy-development`, `deploy-staging`, `deploy-production`, `rollback` | `contents: read`, `deployments: write` | `build-info` artifact; dry-run `deploy-record-<env>.md` / `rollback.md` artifacts; real `createDeployment` calls when not dry-run |
 | `security-rescan.yml` | weekly schedule (Mon 02:00 UTC); `workflow_dispatch` | `gitleaks`, `osv`, `report` | `contents: read`, `issues: write` | `security-rescan-report` artifact; issue filed on blocking gitleaks findings on schedule runs |
 | `release-on-tag.yml` | push tags `v*` | `release` (build, release notes, GitHub Release) | `contents: write` | GitHub Release + `release-notes` artifact |
+| `delivery-telemetry.yml` | weekly schedule (Mon 02:30 UTC); `workflow_dispatch` | `telemetry` (read GitHub API records → audit trail + DORA-style metrics) | `contents: read` | `delivery-telemetry` artifact (`delivery-audit-<ts>.json`, `delivery-telemetry-<ts>.json`/`.md`) |
 
 Adjacent configuration: `.github/dependabot.yml` keeps GitHub Actions and npm dependencies fresh (weekly, targeting `develop`).
 
@@ -84,6 +85,16 @@ deploy-production    (approval via required_reviewers)
 
 - `release-on-tag.yml` triggers on `v*` tags: builds the deployable, generates release notes (commits since the previous tag, or the most recent commits when no previous tag exists), creates a GitHub Release, and uploads the release notes as an artifact.
 - `security-rescan.yml` runs weekly plus on demand: gitleaks + OSV across the whole repo, then a report job writes `security-rescan-<date>.md` and uploads it as an artifact. On schedule runs, a blocking gitleaks failure also opens an issue; `workflow_dispatch` runs do not.
+
+## Delivery telemetry & audit trail
+
+`delivery-telemetry.yml` makes delivery outcomes observable without any external service (ADR 0008). It reads GitHub's native records — the Deployment API, releases, merged PRs, and rollback/incident issues — via `scripts/delivery-telemetry.mjs` and exports three run artifacts:
+
+- `delivery-audit-<ts>.json` — the raw event snapshot: deployments (environment, ref, created_at), releases, merged PRs (merge commit SHA, merged_at), and failure events.
+- `delivery-telemetry-<ts>.json` — derived metrics: deployment frequency per environment, lead time for changes (median merge→first matching deployment), change failure rate (failure events ÷ deployments), and a time-to-recovery proxy (median failure event→next deployment).
+- `delivery-telemetry-<ts>.md` — the human-readable report.
+
+The workflow runs weekly (Mon 02:30 UTC) and on demand via `workflow_dispatch`, reads with the built-in `GITHUB_TOKEN` (`contents: read`), and uploads the three files as a `delivery-telemetry` artifact. Metrics with no matching native events are marked `insufficient-data` and explained — dry-run records are artifacts, not API events, so only real (`dry_run: false` / push-to-main) activity populates the telemetry.
 
 ## Testing model (GitHub native)
 

--- a/docs/decisions/0008-github-native-delivery-telemetry.md
+++ b/docs/decisions/0008-github-native-delivery-telemetry.md
@@ -1,0 +1,22 @@
+# ADR 0008: GitHub-native delivery telemetry over an external observability tool
+
+- **Status:** Accepted
+
+## Context
+
+Phase 7 gives the delivery engine an observability layer: an audit trail of delivery events and DORA-style telemetry (deployment frequency, lead time for changes, change failure rate, time to recovery). Every delivery event is already natively recorded where it happens — GitHub Deployment API records, releases, merged PRs, and issues. Shipping that data to an external observability/analytics service would add a SaaS dependency, credentials, and drift for a learning reference repo.
+
+## Decision
+
+Compute delivery telemetry from GitHub's own API records and export it as run artifacts:
+
+- `scripts/delivery-telemetry.mjs` reads the Deployments, Releases, Pulls, and Issues REST APIs (no external service, no new secrets).
+- It writes a durable audit-trail snapshot (`delivery-audit-<ts>.json`), a machine-readable metrics file (`delivery-telemetry-<ts>.json`), and a human-readable report (`delivery-telemetry-<ts>.md`).
+- A new `delivery-telemetry.yml` workflow runs weekly (plus on demand via `workflow_dispatch`) and uploads them as a run artifact, consistent with ADR 0004.
+- Metrics that have no matching GitHub-native events yet are marked `insufficient-data` and explained rather than invented — a fresh repo or pure dry-run activity legitimately has none.
+
+## Consequences
+
+- Zero external moving parts: the audit trail is GitHub's own record, queried read-only with the built-in `GITHUB_TOKEN`.
+- Telemetry is only as good as the native data: real (`dry_run: false`) deployments and rollback/incident issues populate the metrics; dry-run records are artifacts, not API events, so they do not count.
+- The report is a snapshot per run (retention 7 days); long-term trends would need a downstream store, which is deliberately out of scope here.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -11,5 +11,6 @@ Architecture Decision Records (ADRs) for the PDM delivery engine. Each entry rec
 | [0005](0005-comment-guard-pull-request-number.md) | Guard PR comments with the pull request number | Accepted |
 | [0006](0006-osv-scanner-action-subdirectory-path.md) | osv-scanner-action resolves under a subdirectory path | Accepted |
 | [0007](0007-github-native-over-act.md) | Test workflows natively on GitHub over a local act harness | Accepted |
+| [0008](0008-github-native-delivery-telemetry.md) | GitHub-native delivery telemetry over an external observability tool | Accepted |
 
 Superseded or rejected decisions are removed from the index but the record itself may note the supersession (see [0004](0004-run-artifact-persistence.md)).

--- a/docs/local-runbook.md
+++ b/docs/local-runbook.md
@@ -78,13 +78,26 @@ Scheduled and tag workflows:
 
 - `security-rescan` runs weekly (Mon 02:00 UTC) and on demand via `workflow_dispatch`; on schedule runs a blocking gitleaks failure opens an issue.
 - `release-on-tag` fires on `v*` tags and creates a GitHub Release with generated release notes.
+- `delivery-telemetry` runs weekly (Mon 02:30 UTC) and on demand via `workflow_dispatch`. It reads GitHub's native delivery records (deployments, releases, merged PRs, rollback/incident issues) and uploads the audit trail + DORA-style telemetry as a `delivery-telemetry` artifact (see ADR 0008).
+
+```sh
+gh workflow run delivery-telemetry.yml --ref develop
+# or run it against a feature branch to snapshot its delivery record
+```
+
+You can preview the exporter locally against the live repo:
+
+```sh
+GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=frdrpo/learning-pdm-fintech-delivery-engine \
+  LOOKBACK_DAYS=90 node scripts/delivery-telemetry.mjs /tmp/telemetry
+```
 
 ## Where results land
 
 | Event | Results |
 |---|---|
 | PR run | PR comments (risk report, compliance pass/fail, gate summary) |
-| Non-PR run (`workflow_dispatch`, push, schedule) | Run artifacts: `risk-report`, `gate-report`, `security-rescan-report`, `deploy-record-<env>`, `rollback-record`, `release-notes`, `build-info` — download from the run's "Artifacts" section |
+| Non-PR run (`workflow_dispatch`, push, schedule) | Run artifacts: `risk-report`, `gate-report`, `security-rescan-report`, `delivery-telemetry`, `deploy-record-<env>`, `rollback-record`, `release-notes`, `build-info` — download from the run's "Artifacts" section |
 | Dry-run release | `deploy-<env>.md` records written under `.github/pdm/deployments/` in the job workspace, uploaded as artifacts (never committed) |
 
 ## Troubleshooting
@@ -101,4 +114,5 @@ Scheduled and tag workflows:
 | `make test-gh` errors on push | Push access is required; check your remote and branch protection. |
 | `make test-frontend` fails with `pnpm: command not found` | pnpm is not installed. `brew install pnpm` (or use corepack on Node <25). |
 | Dry-run release produced no Deployment API records | Expected — `dry_run: true` (default) skips `createDeployment` and writes `deploy-<env>.md` artifacts instead. |
+| `delivery-telemetry` metrics report `insufficient-data` | Expected on fresh repos or pure dry-run activity — telemetry reads GitHub-native API records only (ADR 0008); real deployments / rollback or incident issues populate it. |
 | One comment per push on an active PR | Expected — the PR workflows re-run on every `synchronize`. |

--- a/scripts/delivery-telemetry.mjs
+++ b/scripts/delivery-telemetry.mjs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+// Delivery telemetry & audit trail exporter.
+//
+// Usage: node scripts/delivery-telemetry.mjs <outdir>
+//
+// Reads the GitHub-native audit trail (deployments, releases, merged PRs, and
+// rollback/incident issues) via the REST API and derives DORA-style delivery
+// telemetry: deployment frequency, lead time for changes, change failure rate,
+// and a time-to-recovery proxy. Writes three files into <outdir>:
+//
+//   delivery-audit-<ts>.json       raw event snapshot (the audit trail)
+//   delivery-telemetry-<ts>.json   derived metrics (+ per-environment and PR data)
+//   delivery-telemetry-<ts>.md     human-readable report
+//
+// Env:
+//   GITHUB_TOKEN       required — repo read access (the default actions token)
+//   GITHUB_REPOSITORY  owner/repo (set natively by GitHub Actions)
+//   GITHUB_API_URL     API base, defaults to https://api.github.com
+//   LOOKBACK_DAYS      measurement window, default 90
+//
+// Undefined metrics are reported as "insufficient-data" rather than failing:
+// GitHub-native records are the source of truth, and a fresh repo (or pure
+// dry-run activity) legitimately has none yet.
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+
+const outDir = process.argv[2];
+
+if (!outDir) {
+  console.error('usage: node scripts/delivery-telemetry.mjs <outdir>');
+  process.exit(2);
+}
+mkdirSync(outDir, { recursive: true });
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const lookbackDays = Number(process.env.LOOKBACK_DAYS || 90) || 90;
+
+if (!token || !repository) {
+  console.error('GITHUB_TOKEN and GITHUB_REPOSITORY are required.');
+  process.exit(2);
+}
+
+const apiBase = (process.env.GITHUB_API_URL || 'https://api.github.com').replace(/\/$/, '');
+const [owner, repo] = repository.split('/');
+const now = new Date();
+const windowStart = new Date(now.getTime() - lookbackDays * 24 * 60 * 60 * 1000);
+const fail = (value) => ({ status: 'insufficient-data', value: null, note: value });
+
+async function ghGet(path) {
+  const resp = await fetch(`${apiBase}${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'pdm-delivery-telemetry',
+    },
+  });
+  if (!resp.ok) {
+    console.warn(`WARN: ${path} -> ${resp.status} ${resp.statusText}`);
+    return [];
+  }
+  return resp.json();
+}
+
+async function listAll(path, perPage) {
+  const data = await ghGet(`${path}${path.includes('?') ? '&' : '?'}per_page=${perPage}&page=1`);
+  return data && Array.isArray(data) ? data : [];
+}
+
+const inWindow = (iso) => iso && new Date(iso) >= windowStart;
+const isoDate = (iso) => (iso ? new Date(iso).toISOString() : null);
+const median = (nums) => {
+  if (nums.length === 0) return null;
+  const sorted = nums.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+const hoursToParts = (h) => {
+  const days = Math.floor(h / 24);
+  const hours = Math.floor(h % 24);
+  const minutes = Math.round((h - days * 24 - hours) * 60);
+  if (days > 0) return `${days}d ${hours}h`;
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  return `${minutes}m`;
+};
+
+// ---- Audit trail: raw events from the GitHub-native API ---------------------
+const [deployments, releases, closedPulls, issues] = await Promise.all([
+  listAll(`/repos/${owner}/${repo}/deployments`, 100),
+  listAll(`/repos/${owner}/${repo}/releases`, 100),
+  listAll(`/repos/${owner}/${repo}/pulls?state=closed&sort=updated&direction=desc`, 100),
+  listAll(`/repos/${owner}/${repo}/issues?state=all&sort=created&direction=desc`, 100),
+]);
+
+deployments.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+releases.sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+const mergedPulls = closedPulls
+  .filter((p) => p.merged_at)
+  .sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
+
+// A "failure event" is any issue whose title signals a rollback or incident
+// (this repo records dry-run rollbacks as artifacts, so the GitHub-native proxy
+// is issue titles; a dedicated `rollback` label is an even stronger signal).
+const failureEvents = issues
+  .filter(
+    (i) =>
+      !i.pull_request &&
+      inWindow(i.created_at) &&
+      /(rollback|incident|outage|hotfix|regression)/i.test(i.title)
+  )
+  .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+
+const audit = {
+  generated_at: now.toISOString(),
+  repository,
+  lookback_days: lookbackDays,
+  window_start: windowStart.toISOString(),
+  deployments: deployments
+    .filter((d) => inWindow(d.created_at))
+    .map((d) => ({
+      id: d.id,
+      environment: d.environment,
+      ref: d.ref || d.sha,
+      description: d.description || null,
+      created_at: isoDate(d.created_at),
+    })),
+  releases: releases
+    .filter((r) => inWindow(r.published_at))
+    .map((r) => ({ tag: r.tag_name, name: r.name, published_at: isoDate(r.published_at) })),
+  merged_pulls: mergedPulls
+    .filter((p) => inWindow(p.merged_at))
+    .map((p) => ({
+      number: p.number,
+      title: p.title,
+      merge_commit_sha: p.merge_commit_sha,
+      merged_at: isoDate(p.merged_at),
+    })),
+  failure_events: failureEvents.map((i) => ({
+    number: i.number,
+    title: i.title,
+    created_at: isoDate(i.created_at),
+  })),
+};
+
+// ---- Metrics ----------------------------------------------------------------
+
+// Deployment frequency per environment, in deployments per week.
+const envNames = [...new Set(audit.deployments.map((d) => d.environment))];
+const deploymentFrequency = Object.fromEntries(
+  envNames.map((env) => {
+    const count = audit.deployments.filter((d) => d.environment === env).length;
+    return [env, { count, per_week: count / (lookbackDays / 7) }];
+  })
+);
+
+// Lead time for changes: median gap between a merged PR and the first
+// deployment that references the PR's merge commit SHA.
+const leadTimes = audit.merged_pulls
+  .map((pr) => {
+    const deploy = audit.deployments.find((d) => d.ref === pr.merge_commit_sha);
+    if (!deploy) return null;
+    return (new Date(deploy.created_at) - new Date(pr.merged_at)) / (60 * 60 * 1000);
+  })
+  .filter((h) => h !== null && h >= 0);
+const leadTimeHours = median(leadTimes);
+
+// Change failure rate: failure events in the window divided by deployments.
+const changeFailureRate =
+  audit.deployments.length > 0
+    ? { status: 'computed', deployments: audit.deployments.length, failures: failureEvents.length, ratio: failureEvents.length / audit.deployments.length }
+    : fail('no deployments in window');
+
+// Time to recovery (proxy): median gap from a failure event to the next
+// deployment in any environment.
+const recoveries = failureEvents
+  .map((ev) => {
+    const next = audit.deployments.find((d) => new Date(d.created_at) >= new Date(ev.created_at));
+    return next ? (new Date(next.created_at) - new Date(ev.created_at)) / (60 * 60 * 1000) : null;
+  })
+  .filter((h) => h !== null && h >= 0);
+const mttrHours = median(recoveries);
+
+const metrics = {
+  generated_at: now.toISOString(),
+  window: { days: lookbackDays, start: windowStart.toISOString(), end: now.toISOString() },
+  counts: {
+    deployments: audit.deployments.length,
+    releases: audit.releases.length,
+    merged_pulls: audit.merged_pulls.length,
+    failure_events: failureEvents.length,
+  },
+  deployment_frequency_per_week: deploymentFrequency,
+  lead_time_for_changes_hours:
+    leadTimeHours !== null
+      ? { status: 'computed', hours: leadTimeHours, prs_sampled: leadTimes.length }
+      : fail(`no deployment matched a merged PR by merge commit SHA (${leadTimes.length} PRs sampled)`),
+  change_failure_rate: changeFailureRate,
+  time_to_recovery_hours:
+    mttrHours !== null
+      ? { status: 'computed', hours: mttrHours, events_sampled: recoveries.length }
+      : fail('no failure events in window'),
+};
+
+// ---- Reports ----------------------------------------------------------------
+
+const ts = now.toISOString().replace(/[:.]/g, '').slice(0, 13);
+
+writeFileSync(`${outDir}/delivery-audit-${ts}.json`, JSON.stringify(audit, null, 2) + '\n');
+writeFileSync(`${outDir}/delivery-telemetry-${ts}.json`, JSON.stringify(metrics, null, 2) + '\n');
+
+const freqLines =
+  Object.keys(deploymentFrequency).length === 0
+    ? ['  - _No deployments recorded in the window._']
+    : Object.entries(deploymentFrequency).map(
+        ([env, v]) =>
+          `  - **${env}**: ${v.count} deployment(s) in ${lookbackDays} days (${v.per_week.toFixed(2)}/week)`
+      );
+
+const leadLine =
+  metrics.lead_time_for_changes_hours.status === 'computed'
+    ? `  - **median**: ${hoursToParts(metrics.lead_time_for_changes_hours.hours)} (sampled ${metrics.lead_time_for_changes_hours.prs_sampled} merged PR${metrics.lead_time_for_changes_hours.prs_sampled === 1 ? '' : 's'})`
+    : `  - _${metrics.lead_time_for_changes_hours.note}._`;
+
+const cfr = metrics.change_failure_rate;
+const cfrLine =
+  cfr.status === 'computed'
+    ? `  - **${(cfr.ratio * 100).toFixed(1)}%** (${cfr.failures} failure event${cfr.failures === 1 ? '' : 's'} over ${cfr.deployments} deployment${cfr.deployments === 1 ? '' : 's'})`
+    : `  - _${cfr.note}._`;
+
+const mttr = metrics.time_to_recovery_hours;
+const mttrLine =
+  mttr.status === 'computed'
+    ? `  - **median**: ${hoursToParts(mttr.hours)} (sampled ${mttr.events_sampled} event${mttr.events_sampled === 1 ? '' : 's'})`
+    : `  - _${mttr.note}._`;
+
+const report = [
+  '## Delivery Telemetry & Audit Trail',
+  '',
+  `_Generated ${now.toISOString()} | source: GitHub-native records (deployments, releases, merged PRs, rollback/incident issues) | window: last ${lookbackDays} days_`,
+  '',
+  '### Deployment frequency',
+  ...freqLines,
+  '',
+  '### Lead time for changes',
+  leadLine,
+  '',
+  '### Change failure rate',
+  cfrLine,
+  '',
+  '### Time to recovery (proxy)',
+  mttrLine,
+  '',
+  '### Counts in window',
+  `  - **Deployments**: ${metrics.counts.deployments}`,
+  `  - **Releases**: ${metrics.counts.releases}`,
+  `  - **Merged PRs to the base branch**: ${metrics.counts.merged_pulls}`,
+  `  - **Rollback/incident issues**: ${metrics.counts.failure_events}`,
+  '',
+  '### Audit trail',
+  '',
+  `_The raw event snapshot lives in \`delivery-audit-${ts}.json\` (deployments, releases, PRs, and failure events); the metrics machine-read it from \`delivery-telemetry-${ts}.json\`. Metrics marked insufficient-data mean the GitHub-native record has no matching events yet — e.g. a new repo or untouched-by-real-activity environments._`,
+  '',
+  '_Generated by `scripts/delivery-telemetry.mjs` — reads the GitHub Deployment/Releases/Pulls/Issues APIs; pick a longer `LOOKBACK_DAYS` or real (non-dry-run) deployments to populate the DORA-style metrics._',
+  '',
+].join('\n');
+
+writeFileSync(`${outDir}/delivery-telemetry-${ts}.md`, report);
+console.log(`Wrote delivery-audit-${ts}.json, delivery-telemetry-${ts}.json/.md`);
+const envSummary = Object.keys(deploymentFrequency)
+  .map((env) => `${env}:${deploymentFrequency[env].count}`)
+  .join(', ') || 'none';
+console.log(`deployment_counts=${envSummary}`);
+console.log(`deployments_total=${audit.deployments.length}`);
+console.log(`merged_pulls=${audit.merged_pulls.length}`);
+console.log(`failure_events=${failureEvents.length}`);


### PR DESCRIPTION
Implements Phase 7 from docs/ROADMAP.md — makes delivery outcomes observable from GitHub-native records.

- `scripts/delivery-telemetry.mjs`: reads the Deployments/Releases/Pulls/Issues APIs and exports an audit-trail snapshot plus DORA-style metrics (deployment frequency, lead time for changes, change failure rate, time-to-recovery proxy). Insufficient data is reported as such, never invented.
- `delivery-telemetry.yml`: weekly (Mon 02:30 UTC) + `workflow_dispatch`, uploads `delivery-telemetry` artifacts (`delivery-audit-<ts>.json`, `delivery-telemetry-<ts>.json/.md`).
- ADR 0008: GitHub-native telemetry over an external observability tool.
- Docs updated: ROADMAP Phase 7 section, architecture workflow map + telemetry section, runbook, agent guide, README.

Validated: `make lint` green, exporter tested against the live repo API.