### PR TITLE
feat(simulator): interactive release-train simulator route (Phase 12)

### DIFF
--- a/frontend/src/app/simulator/page.tsx
+++ b/frontend/src/app/simulator/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { SimulationPanel } from "@/components/simulation-panel";
+
+export const metadata: Metadata = {
+  title: "Release Train Simulator",
+  description:
+    "Model a fixed-cadence release train: configure capacity, gate pass rate, and seed to see which features board on time.",
+};
+
+export default function SimulatorPage() {
+  return (
+    <>
+      <header className="mx-auto w-full max-w-5xl px-6 pt-16 text-center">
+        <h1 className="text-4xl font-bold tracking-tight text-white">
+          Release train simulator
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-400">
+          Tune the train capacity, gate pass rate, and seed to see a
+          deterministic what-if simulation of features boarding each train.
+        </p>
+      </header>
+      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
+        <SimulationPanel />
+      </main>
+      <footer className="border-t border-white/10 py-10 text-center text-sm text-slate-500">
+        PDM reference implementation — simulation outputs are labeled, never
+        real delivery records.
+      </footer>
+    </>
+  );
+}

--- a/frontend/src/components/hero.tsx
+++ b/frontend/src/components/hero.tsx
@@ -36,10 +36,10 @@ export function Hero() {
             See the pipeline
           </a>
           <a
-            href="#workflows"
+            href="/simulator"
             className="rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-slate-200 transition-colors hover:border-white/30"
           >
-            Explore workflows
+            Try the simulator
           </a>
         </div>
       </div>

--- a/frontend/src/components/simulation-panel.test.tsx
+++ b/frontend/src/components/simulation-panel.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SimulationPanel } from "./simulation-panel";
+
+describe("SimulationPanel", () => {
+  describe("positive scenarios", () => {
+    it("runs the model on mount and shows a train schedule", () => {
+      render(<SimulationPanel />);
+      expect(screen.getByRole("heading", { name: /train 1/i })).toBeInTheDocument();
+      expect(screen.getByText("feat-a")).toBeInTheDocument();
+      expect(screen.getByText("feat-b")).toBeInTheDocument();
+      expect(screen.getByText("feat-c")).toBeInTheDocument();
+    });
+
+    it("shows the on-time rate summary", () => {
+      render(<SimulationPanel />);
+      const metric = screen.getByText(/on-time rate/i).closest("div");
+      expect(metric).toHaveTextContent("100%");
+    });
+
+    it("spreads features across trains when capacity drops", () => {
+      render(<SimulationPanel />);
+      expect(screen.queryByRole("heading", { name: /train 2/i })).not.toBeInTheDocument();
+      fireEvent.change(screen.getByLabelText(/capacity/i), {
+        target: { value: "1" },
+      });
+      expect(screen.getByRole("heading", { name: /train 1/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /train 2/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /train 3/i })).toBeInTheDocument();
+    });
+  });
+
+  describe("negative scenarios", () => {
+    it("boards nothing when the gate always fails", () => {
+      render(<SimulationPanel />);
+      fireEvent.change(screen.getByLabelText(/gate pass rate/i), {
+        target: { value: "0" },
+      });
+      expect(screen.queryByRole("heading", { name: /train 1/i })).not.toBeInTheDocument();
+      expect(screen.getByText(/no features boarded/i)).toBeInTheDocument();
+    });
+
+    it("keeps the simulated labeling visible on every output", () => {
+      render(<SimulationPanel />);
+      expect(screen.getAllByText(/simulated/i).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/kind: "simulation"/i).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/components/simulation-panel.tsx
+++ b/frontend/src/components/simulation-panel.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { simulateReleaseTrain, type ReleaseTrainConfig } from "@/lib/release-train";
+
+type PanelConfig = {
+  capacity: number;
+  gatePassRatePct: number;
+  trainIntervalDays: number;
+  seed: number;
+};
+
+const DEFAULT_PANEL: PanelConfig = {
+  capacity: 3,
+  gatePassRatePct: 100,
+  trainIntervalDays: 14,
+  seed: 42,
+};
+
+function toModelConfig(config: PanelConfig): ReleaseTrainConfig {
+  return {
+    trainIntervalDays: config.trainIntervalDays,
+    capacity: config.capacity,
+    gatePassRate: config.gatePassRatePct / 100,
+    slipPolicy: "carry",
+    seed: config.seed,
+    maxTrains: 10,
+    backlog: [
+      { id: "feat-a", size: 2, readiness: 1 },
+      { id: "feat-b", size: 3, readiness: 1 },
+      { id: "feat-c", size: 1, readiness: 1 },
+    ],
+  };
+}
+
+export function SimulationPanel() {
+  const [config, setConfig] = useState<PanelConfig>(DEFAULT_PANEL);
+
+  const result = useMemo(
+    () => simulateReleaseTrain(toModelConfig(config)),
+    [config],
+  );
+
+  return (
+    <div className="w-full max-w-5xl space-y-8">
+      <div className="flex items-center gap-3">
+        <h2 className="text-2xl font-semibold text-white">
+          Release train simulator
+        </h2>
+        <span className="rounded-full border border-violet-400/30 bg-violet-400/10 px-3 py-1 text-xs text-violet-300">
+          Simulated
+        </span>
+      </div>
+
+      <form
+        role="form"
+        onSubmit={(e) => e.preventDefault()}
+        className="grid gap-6 rounded-2xl border border-white/10 bg-white/5 p-6 sm:grid-cols-2 lg:grid-cols-4"
+      >
+        <label className="flex flex-col gap-1.5 text-sm text-slate-300">
+          Train capacity
+          <select
+            aria-label="Train capacity"
+            className="rounded-lg border border-white/15 bg-slate-900 px-3 py-2 text-slate-100"
+            value={config.capacity}
+            onChange={(e) =>
+              setConfig({ ...config, capacity: Number(e.target.value) })
+            }
+          >
+            {[1, 2, 3, 4, 5].map((n) => (
+              <option key={n} value={n}>
+                {n} feature{n > 1 ? "s" : ""} per train
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1.5 text-sm text-slate-300">
+          Gate pass rate (%)
+          <input
+            aria-label="Gate pass rate"
+            type="number"
+            min={0}
+            max={100}
+            step={5}
+            className="rounded-lg border border-white/15 bg-slate-900 px-3 py-2 text-slate-100"
+            value={config.gatePassRatePct}
+            onChange={(e) =>
+              setConfig({
+                ...config,
+                gatePassRatePct: Number(e.target.value),
+              })
+            }
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5 text-sm text-slate-300">
+          Train interval (days)
+          <input
+            aria-label="Train interval"
+            type="number"
+            min={1}
+            step={1}
+            className="rounded-lg border border-white/15 bg-slate-900 px-3 py-2 text-slate-100"
+            value={config.trainIntervalDays}
+            onChange={(e) =>
+              setConfig({ ...config, trainIntervalDays: Number(e.target.value) })
+            }
+          />
+        </label>
+
+        <label className="flex flex-col gap-1.5 text-sm text-slate-300">
+          Seed
+          <input
+            aria-label="Seed"
+            type="number"
+            step={1}
+            className="rounded-lg border border-white/15 bg-slate-900 px-3 py-2 text-slate-100"
+            value={config.seed}
+            onChange={(e) => setConfig({ ...config, seed: Number(e.target.value) })}
+          />
+        </label>
+      </form>
+
+      <section className="grid gap-4 sm:grid-cols-3">
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <dt className="text-xs uppercase tracking-widest text-slate-400">
+            On-time rate
+          </dt>
+          <dd className="mt-2 text-2xl font-semibold text-emerald-300">
+            {Math.round(result.onTimeRate * 100)}%
+          </dd>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <dt className="text-xs uppercase tracking-widest text-slate-400">
+            Throughput
+          </dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-100">
+            {Math.round(result.throughput * 100)}%
+          </dd>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-white/5 p-4">
+          <dt className="text-xs uppercase tracking-widest text-slate-400">
+            Avg delay
+          </dt>
+          <dd className="mt-2 text-2xl font-semibold text-slate-100">
+            {result.averageDelayTrains.toFixed(1)} trains
+          </dd>
+        </div>
+      </section>
+
+      {result.trains.length === 0 ? (
+        <p className="rounded-xl border border-white/10 bg-white/5 p-6 text-sm text-slate-400">
+          No features boarded — the gate never passed for this configuration.
+        </p>
+      ) : (
+        <section className="space-y-4">
+          <h3 className="text-lg font-semibold text-slate-200">
+            Simulated train schedule
+          </h3>
+          {result.trains.map((train) => (
+            <article
+              key={train.train}
+              className="rounded-xl border border-white/10 bg-white/5 p-4"
+            >
+              <header className="flex items-center justify-between">
+                <h4 className="font-medium text-slate-100">Train {train.train}</h4>
+                <span className="rounded-full border border-violet-400/30 bg-violet-400/10 px-2 py-0.5 text-[11px] text-violet-300">
+                  Kind: &quot;simulation&quot;
+                </span>
+              </header>
+              <ul className="mt-3 flex flex-wrap gap-2">
+                {train.features.map((id) => (
+                  <li
+                    key={id}
+                    className="rounded-md border border-white/10 bg-slate-900 px-2.5 py-1 text-xs text-slate-200"
+                  >
+                    {id}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Phase 12 — Interactive Surface

TDD-first `/simulator` route wired to the Phase 11 model.

### Changes
- `src/components/simulation-panel.tsx` + tests — client component with config controls (capacity, gate pass rate, train interval, seed); renders train schedule + on-time rate / throughput / avg-delay summary; every output labeled simulated.
- `src/app/simulator/page.tsx` — static route (prerendered).
- `src/components/hero.tsx` — link to `/simulator` from the landing page.

**Gates:** `quality-gate` (required), `risk-health-check`, `compliance-guardrail`
**Acceptance:** `make test-frontend` green (32 tests); route reachable; native gates verified via PR to main.