### PR TITLE
fix(telemetry): count failure events by label, not title regex

### DIFF
--- a/docs/plans/roadmap-phase-8-10-maiden-voyage.md
+++ b/docs/plans/roadmap-phase-8-10-maiden-voyage.md
@@ -93,7 +93,7 @@ independent)            (needs P8 baseline: real deploys/release)
 **Goal:** cover the remaining README promises — "agile release trains" — and give CFR/MTTR real data, then leave a path for adopting this engine in a fresh product.
 
 - **P10-T1** — Release train cadence: document a train calendar (train interval, content, readiness cutoffs) and extend `delivery-telemetry.mjs` with an on-time delivery signal; record the decision as an ADR. *Gate:* `delivery-telemetry`. *Touchpoints:* `docs/decisions/0009-*.md`, `scripts/`, `.github/pdm/workflows/` (+ `make sync`).
-- **P10-T2** — Controlled failure & recovery drill: deploy a deliberately introduced regression to a lower environment, exercise `rollback_to`, and file one carefully-named issue (per `delivery-telemetry.mjs` title taxonomy) so **CFR and the MTTR proxy compute real values** from native records. *Gates:* `release-pipeline`, `delivery-telemetry`.
+- **P10-T2** — Controlled failure & recovery drill: deploy a deliberately introduced regression to a lower environment, exercise `rollback_to`, and file one carefully-*labeled* issue (an explicit `rollback`/`incident` label — `delivery-telemetry.mjs` counts failure events by label, never by title, since feature tasks mention rollback too) so **CFR and the MTTR proxy compute real values** from native records. *Gates:* `release-pipeline`, `delivery-telemetry`.
 - **P10-T3** — AI-assisted release notes / PR summaries: extend the release-note generation and risk-report with engine-drafted summaries, keeping the "never invent telemetry" ethos intact (draft ≠ metric). *Gates:* `risk-health-check`, `release-pipeline`.
 - **P10-T4** — Reusable engine template: document a copy-kit/bootstrapping path (checklist + scripts usage) so a new product team can adopt this engine without reading every ADR; README/runbook updates. *Touchpoints:* docs/, README.md.
 
@@ -115,7 +115,7 @@ independent)            (needs P8 baseline: real deploys/release)
 | The first real promotion surprises us (real `createDeployment` vs dry-run habits) | Keep `dry_run: true` as the dispatch default (ADR 0002); only P8-T2 explicitly sets `dry_run: false`; docs label that dispatch as the controlled flight |
 | Pages publish needs static export (`next build` emits `.next`, not a static site) | P8-T5 may require `output: 'export'` or equivalent in `frontend/`; verify the `github-pages` environment actually has a Pages site enabled before wiring `DEPLOY_VERIFY_URL` |
 | CFR/MTTR walk back to `insufficient-data` (no recorded failure) | P10-T2 deliberately creates one controlled failure on a lower env with a taxonomy-correct issue title, then a recovery deploy |
-| Failure-drill issue title pollutes change-failure metrics | Follow `scripts/delivery-telemetry.mjs` naming discipline exactly; review the issue title before filing (it intentionally counts) |
+| Failure-drill issue title pollutes change-failure metrics | Failure events are counted by a dedicated `rollback`/`incident` label, not title text — feature tasks mentioning rollback can't count; the drill's labeled issue (P10-T2) intentionally does |
 | Telemetry stays `insufficient-data` because events are sparse in a learning repo | Metrics are *real and explained*, never padded; ROADMAP documents why `insufficient-data` remains for any unexercised metric |
 | Docs drift as workflows change | Same-PR doc updates (architecture map, runbook, ADR log) per the repo's Definition of Done |
 

--- a/scripts/delivery-telemetry.mjs
+++ b/scripts/delivery-telemetry.mjs
@@ -98,15 +98,20 @@ const mergedPulls = closedPulls
   .filter((p) => p.merged_at)
   .sort((a, b) => new Date(b.merged_at) - new Date(a.merged_at));
 
-// A "failure event" is any issue whose title signals a rollback or incident
-// (this repo records dry-run rollbacks as artifacts, so the GitHub-native proxy
-// is issue titles; a dedicated `rollback` label is an even stronger signal).
+// A "failure event" is any issue carrying a dedicated failure label
+// (`rollback`, `incident`, `outage`, `hotfix`, or `regression`). Title text is
+// deliberately NOT inspected: feature tasks (e.g. "Rollback + post-deploy
+// verification") often mention rollback and must not count as failures.
+// P10-T2's controlled drill files a deliberately labeled issue so CFR/MTTR
+// compute a real, intended value from a single event.
+const failureLabel = /^(rollback|incident|outage|hotfix|regression)$/i;
 const failureEvents = issues
   .filter(
     (i) =>
       !i.pull_request &&
       inWindow(i.created_at) &&
-      /(rollback|incident|outage|hotfix|regression)/i.test(i.title)
+      Array.isArray(i.labels) &&
+      i.labels.some((l) => failureLabel.test(l.name))
   )
   .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
 
@@ -165,10 +170,12 @@ const leadTimes = audit.merged_pulls
 const leadTimeHours = median(leadTimes);
 
 // Change failure rate: failure events in the window divided by deployments.
+// Like MTTR, CFR only computes when a failure event is actually on record —
+// a 0% CFR on placeholder/dry-run deployments would be invented confidence.
 const changeFailureRate =
-  audit.deployments.length > 0
+  failureEvents.length > 0 && audit.deployments.length > 0
     ? { status: 'computed', deployments: audit.deployments.length, failures: failureEvents.length, ratio: failureEvents.length / audit.deployments.length }
-    : fail('no deployments in window');
+    : fail('no failure events in window');
 
 // Time to recovery (proxy): median gap from a failure event to the next
 // deployment in any environment.


### PR DESCRIPTION
Discovered during P8-T4 telemetry truthing: the `/rollback/` title regex matched feature task #23 ('[P4] T4.4 Rollback + post-deploy verification'), producing a false 5.9% CFR and a bogus MTTR readout — violating the plan's 'CFR/MTTR stay insufficient-data until P10-T2'.

Fix: failure events are detected by a dedicated `rollback`/`incident` label (the stronger signal the script comment already named), not title text. CFR now matches MTTR's behavior — `insufficient-data` until a labeled failure event exists.

Docs: P10-T2 updated to file a labeled issue (label, not title taxonomy); risk matrix row updated.