### PR TITLE
feat(pages): publish static-exported frontend to GitHub Pages for live verify

### DIFF
--- a/.github/pdm/workflows/publish-pages.yml
+++ b/.github/pdm/workflows/publish-pages.yml
@@ -1,0 +1,93 @@
+name: PDM Publish GitHub Pages
+
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# Publishes the static-exported frontend to GitHub Pages so release-pipeline's
+# post-deploy verify step has a live URL to curl (DEPLOY_VERIFY_URL). The
+# `github-pages` environment restricts to the develop branch (branch policy).
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build static export
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Detect frontend toolchain
+        id: detect
+        shell: bash
+        run: |
+          if [[ -f package.json ]]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ -f pnpm-lock.yaml ]]; then
+            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up pnpm
+        if: steps.detect.outputs.has_lockfile == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.21.0
+
+      - name: Set up Node.js
+        if: steps.detect.outputs.has_lockfile == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        if: steps.detect.outputs.has_lockfile == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build static export
+        if: steps.detect.outputs.found == 'true'
+        run: pnpm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /learning-pdm-fintech-delivery-engine
+
+      - name: Configure Pages
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/out
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -1,0 +1,93 @@
+name: PDM Publish GitHub Pages
+
+# Docs: architecture map, ADRs, and runbook live in docs/ (see docs/architecture.md).
+# Publishes the static-exported frontend to GitHub Pages so release-pipeline's
+# post-deploy verify step has a live URL to curl (DEPLOY_VERIFY_URL). The
+# `github-pages` environment restricts to the develop branch (branch policy).
+
+on:
+  push:
+    branches: [ develop ]
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build static export
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Detect frontend toolchain
+        id: detect
+        shell: bash
+        run: |
+          if [[ -f package.json ]]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ -f pnpm-lock.yaml ]]; then
+            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up pnpm
+        if: steps.detect.outputs.has_lockfile == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.21.0
+
+      - name: Set up Node.js
+        if: steps.detect.outputs.has_lockfile == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        if: steps.detect.outputs.has_lockfile == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Build static export
+        if: steps.detect.outputs.found == 'true'
+        run: pnpm run build
+        env:
+          NEXT_PUBLIC_BASE_PATH: /learning-pdm-fintech-delivery-engine
+
+      - name: Configure Pages
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        if: steps.detect.outputs.found == 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: frontend/out
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,10 @@ deploy-production    (approval via required_reviewers)
 - `release-on-tag.yml` triggers on `v*` tags: builds the deployable, generates release notes (commits since the previous tag, or the most recent commits when no previous tag exists), creates a GitHub Release, and uploads the release notes as an artifact.
 - `security-rescan.yml` runs weekly plus on demand: gitleaks + OSV across the whole repo, then a report job writes `security-rescan-<date>.md` and uploads it as an artifact. On schedule runs, a blocking gitleaks failure also opens an issue; `workflow_dispatch` runs do not.
 
+## GitHub Pages publish (live verify target)
+
+`publish-pages.yml` publishes the static-exported frontend to GitHub Pages on every push to `develop` (the `github-pages` environment's branch policy) plus `workflow_dispatch`. The `github-pages` environment restricts deployment to `develop`; the publish build sets `NEXT_PUBLIC_BASE_PATH=/learning-pdm-fintech-delivery-engine` for the subpath, and the Pages site becomes the live target for `release-pipeline`'s post-deploy verify step via the repo variable `DEPLOY_VERIFY_URL`. The frontend build uses `output: 'export'` so `next build` emits a static site into `frontend/out`.
+
 ## Delivery telemetry & audit trail
 
 `delivery-telemetry.yml` makes delivery outcomes observable without any external service (ADR 0008). It reads GitHub's native records — the Deployment API, releases, merged PRs, and rollback/incident issues — via `scripts/delivery-telemetry.mjs` and exports three run artifacts:

--- a/docs/local-runbook.md
+++ b/docs/local-runbook.md
@@ -80,6 +80,7 @@ Scheduled and tag workflows:
 - `release-on-tag` fires on `v*` tags and creates a GitHub Release with generated release notes.
 - `delivery-telemetry` runs weekly (Mon 02:30 UTC) and on demand via `workflow_dispatch`. It reads GitHub's native delivery records (deployments, releases, merged PRs, rollback/incident issues) and uploads the audit trail + DORA-style telemetry as a `delivery-telemetry` artifact (see ADR 0008).
 - `release-train-simulator` runs on demand via `workflow_dispatch`. It runs the deterministic release-train model headlessly and uploads a `release-train-simulation` artifact (JSON + markdown). It creates no deployments, releases, PRs, or issues — simulated outputs are labeled artifacts only (ADR 0010), so telemetry is unaffected.
+- `publish-pages` publishes the static-exported frontend to GitHub Pages on every push to `develop` (the `github-pages` environment branch policy) plus `workflow_dispatch`. The Pages site is the live target for `release-pipeline`'s post-deploy verify step via the `DEPLOY_VERIFY_URL` repo variable.
 
 ```sh
 gh workflow run delivery-telemetry.yml --ref develop

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "export",
+  trailingSlash: true,
+  images: { unoptimized: true },
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
 };
 
 export default nextConfig;


### PR DESCRIPTION
P8-T5 — live verify target.

- `frontend/next.config.ts`: `output: 'export'`, trailingSlash, env-driven `basePath` so the static site serves correctly under the Pages subpath.
- New canonical `publish-pages.yml` (synced to `.github/workflows/`): builds the static export on pushes to `develop` (the `github-pages` branch policy) + `workflow_dispatch`, then deploys to the `github-pages` environment.
- Sets repo variable `DEPLOY_VERIFY_URL` -> https://frdrpo.github.io/learning-pdm-fintech-delivery-engine/ (once Pages deploys).
- Docs: architecture map + runbook updated.

Repo variable `DEPLOY_VERIFY_URL` already set via API. After merge, the push-to-develop Pages run publishes the site; then a release-pipeline run exercises the verify step against the live URL.