### PR TITLE
fix(release-pipeline): map DEPLOY_VERIFY_URL into verify step env

### DIFF
--- a/.github/pdm/workflows/release-pipeline.yml
+++ b/.github/pdm/workflows/release-pipeline.yml
@@ -140,6 +140,8 @@ jobs:
 
       - name: Verify development deployment
         shell: bash
+        env:
+          DEPLOY_VERIFY_URL: ${{ vars.DEPLOY_VERIFY_URL || '' }}
         run: |
           if [[ -n "${DEPLOY_VERIFY_URL:-}" ]]; then
             echo "::notice::Verifying development at ${DEPLOY_VERIFY_URL}"
@@ -210,6 +212,8 @@ jobs:
 
       - name: Verify staging deployment
         shell: bash
+        env:
+          DEPLOY_VERIFY_URL: ${{ vars.DEPLOY_VERIFY_URL || '' }}
         run: |
           if [[ -n "${DEPLOY_VERIFY_URL:-}" ]]; then
             echo "::notice::Verifying staging at ${DEPLOY_VERIFY_URL}"
@@ -280,6 +284,8 @@ jobs:
 
       - name: Verify production deployment
         shell: bash
+        env:
+          DEPLOY_VERIFY_URL: ${{ vars.DEPLOY_VERIFY_URL || '' }}
         run: |
           if [[ -n "${DEPLOY_VERIFY_URL:-}" ]]; then
             echo "::notice::Verifying production at ${DEPLOY_VERIFY_URL}"

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -140,6 +140,8 @@ jobs:
 
       - name: Verify development deployment
         shell: bash
+        env:
+          DEPLOY_VERIFY_URL: ${{ vars.DEPLOY_VERIFY_URL || '' }}
         run: |
           if [[ -n "${DEPLOY_VERIFY_URL:-}" ]]; then
             echo "::notice::Verifying development at ${DEPLOY_VERIFY_URL}"
@@ -210,6 +212,8 @@ jobs:
 
       - name: Verify staging deployment
         shell: bash
+        env:
+          DEPLOY_VERIFY_URL: ${{ vars.DEPLOY_VERIFY_URL || '' }}
         run: |
           if [[ -n "${DEPLOY_VERIFY_URL:-}" ]]; then
             echo "::notice::Verifying staging at ${DEPLOY_VERIFY_URL}"
@@ -280,6 +284,8 @@ jobs:
 
       - name: Verify production deployment
         shell: bash
+        env:
+          DEPLOY_VERIFY_URL: ${{ vars.DEPLOY_VERIFY_URL || '' }}
         run: |
           if [[ -n "${DEPLOY_VERIFY_URL:-}" ]]; then
             echo "::notice::Verifying production at ${DEPLOY_VERIFY_URL}"


### PR DESCRIPTION
Repo variables are not auto-injected into the runner shell; the post-deploy verify steps must read `DEPLOY_VERIFY_URL` via the `vars` context. Without this, even though the variable is set, the steps logged 'skipping live verification'. Verified at run 32023234614 (confirm skipped despite variable being set).