### PR TITLE
fix(release-on-tag): use github.ref_name in artifact path

### DIFF
--- a/.github/pdm/workflows/release-on-tag.yml
+++ b/.github/pdm/workflows/release-on-tag.yml
@@ -105,5 +105,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-notes
-          path: .github/pdm/releases/release-notes-${GITHUB_REF_NAME}.md
+          path: .github/pdm/releases/release-notes-${{ github.ref_name }}.md
           retention-days: 7

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -105,5 +105,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: release-notes
-          path: .github/pdm/releases/release-notes-${GITHUB_REF_NAME}.md
+          path: .github/pdm/releases/release-notes-${{ github.ref_name }}.md
           retention-days: 7


### PR DESCRIPTION
upload-artifact does not shell-expand the `path` field, so `${GITHUB_REF_NAME}` produced a warn-only 'no files found' annotation on the v0.1.0 run even though the release was created. Switch to `${{ github.ref_name }}` so the release-notes artifact actually uploads.