### PR TITLE
docs(plans): mark Phase 8 complete (maiden voyage first delivery flight)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -152,7 +152,7 @@ Full scope and issue mapping live in `docs/plans/release-train-simulator.md`.
 
 Each phase is a **branch off `develop` + PR**, following the existing repo flow. Phases 2–5 run as parallel tracks after Phase 1 merges green. Phase 5 can start immediately and absorb notes from other tracks.
 
-> **Status:** Phases 0–8 complete. Track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main` plus `workflow_dispatch` runs (dispatchable from `develop`, the default branch).
+> **Status:** Phases 0–8 complete. Track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main` plus `workflow_dispatch` runs (dispatchable from `develop`, the default branch). **Phase 8–10 chapter (maiden voyage)** in-flight — see `docs/plans/roadmap-phase-8-10-maiden-voyage.md`; Phase 8 (first real delivery flight: `develop`→`main` promotion, real dev/staging/prod deployments, release `v0.1.0`, baseline DORA telemetry, GitHub Pages live verify target) is complete.
 
 ## 14. Definition of Done (every phase)
 

--- a/docs/plans/roadmap-phase-8-10-maiden-voyage.md
+++ b/docs/plans/roadmap-phase-8-10-maiden-voyage.md
@@ -1,6 +1,6 @@
 # Learning PDM: Delivery Engine — Roadmap (Phases 8–10: "What's Next")
 
-Status: in-flight (2026-08-17). Tracked as GitHub issues `[P8] T8.*`–`[P10] T10.*`. P8-T1 (first real gated promotion `develop` → `main`) merged as PR #84 (merge commit `e94d9ef`). P8-T2 real promotion flight done (run 32019424411: dev/staging/prod `createDeployment` records on `30f6193`). P8-T3 done (release `v0.1.0` on `e94d9ef`). P8-T4 done — baseline DORA readout (run 32022529571, window 90d): deployment frequency dev 0.62/wk, staging 0.47/wk, prod 0.47/wk; lead time median 32m; CFR and MTTR `insufficient-data` (per plan, until P10-T2's labeled drill).
+Status: in-flight (2026-08-17). Tracked as GitHub issues `[P8] T8.*`–`[P10] T10.*`. **Phase 8 complete** — P8-T1 (first real gated promotion `develop` → `main`) merged as PR #84 (merge commit `e94d9ef`); P8-T2 real promotion flight (run 32019424411: dev/staging/prod `createDeployment` on `30f6193`); P8-T3 release `v0.1.0` on `e94d9ef`; P8-T4 baseline DORA readout (run 32022529571, 90d: DF dev 0.62/wk, staging 0.47/wk, prod 0.47/wk; LT median 32m; CFR/MTTR `insufficient-data` until P10-T2); P8-T5 GitHub Pages live verify target live (200 on `/` and `/simulator/`) with `release-pipeline` verify executing against `DEPLOY_VERIFY_URL` on dev/staging/prod (run 32023618678).
 
 ## 1. Purpose
 


### PR DESCRIPTION
Marks Phase 8 (maiden voyage) complete in both the ROADMAP and the Phase 8–10 plan doc after all five tasks were verified natively on GitHub.