### PR TITLE
feat(frontend): delivery dashboard + release-train readiness model

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,106 @@
+import type { Metadata } from "next";
+import { CompliancePosture } from "@/components/compliance-posture";
+import { DeliveryDashboard } from "@/components/delivery-dashboard";
+import { FeatureStatusCard } from "@/components/feature-status-card";
+
+export const metadata: Metadata = {
+  title: "Delivery Dashboard",
+  description:
+    "A delivery-readiness view: quality gates, the next release-train window, compliance posture, and feature boarding status.",
+};
+
+const SNAPSHOT = {
+  gates: {
+    lint: "pass",
+    test: "pass",
+    build: "pass",
+    compliance: "pass",
+  } as const,
+  train: {
+    featuresReady: 3,
+    featuresTotal: 4,
+    gateHealth: {
+      lint: "pass",
+      test: "pass",
+      build: "pass",
+      compliance: "pass",
+    } as const,
+    daysUntilTrain: 5,
+  },
+};
+
+const CONTROLS = [
+  { id: "secrets", name: "Secret scanning (gitleaks / trufflehog)", status: "pass" },
+  { id: "vulns", name: "Dependency scanning (OSV)", status: "pass" },
+  { id: "sast", name: "Code-health & diff risk review", status: "pass" },
+  { id: "regulatory", name: "Regulatory attestation", status: "pending" },
+] as const;
+
+const FEATURES = [
+  {
+    name: "Live verify target",
+    description:
+      "Pages site on demand — the release pipeline curls DEPLOY_VERIFY_URL after each promotion.",
+    rank: "ready",
+    train: 2,
+  },
+  {
+    name: "Dev-staging-prod promotion",
+    description:
+      "Real Deployment API records with reviewer approvals on staging and production.",
+    rank: "ready",
+    train: 2,
+  },
+  {
+    name: "Failure & recovery drill",
+    description:
+      "Controlled regression + rollback so CFR/MTTR compute real values from native records.",
+    rank: "in-flight",
+    train: 3,
+  },
+  {
+    name: "Regulatory attestation",
+    description: "Formal evidence pack for audit-gated environments.",
+    rank: "blocked",
+  },
+] as const;
+
+export default function DashboardPage() {
+  return (
+    <>
+      <header className="mx-auto w-full max-w-5xl px-6 pt-16 text-center">
+        <h1 className="text-4xl font-bold tracking-tight text-white">
+          Delivery dashboard
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-lg text-slate-400">
+          A single view of what is ready to board the next release train and
+          what is blocking it.
+        </p>
+      </header>
+      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
+        <DeliveryDashboard gates={SNAPSHOT.gates} train={SNAPSHOT.train} />
+        <section className="mt-8 grid gap-6 lg:grid-cols-2">
+          <CompliancePosture controls={CONTROLS} />
+          <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
+            <h3 className="text-lg font-semibold text-white">
+              Feature boarding status
+            </h3>
+            <div className="mt-4 grid gap-4">
+              {FEATURES.map((feature) => (
+                <FeatureStatusCard key={feature.name} {...feature} />
+              ))}
+            </div>
+          </section>
+        </section>
+        <p className="mt-8 text-center text-xs text-slate-500">
+          Sample snapshot for illustration — the live view is generated from
+          GitHub-native delivery records by scripts/delivery-telemetry.mjs.
+        </p>
+      </main>
+      <footer className="border-t border-white/10 py-10 text-center text-sm text-slate-500">
+        PDM reference implementation — telemetry is read from real events, never
+        invented.
+      </footer>
+    </>
+  );
+}

--- a/frontend/src/components/compliance-posture.test.tsx
+++ b/frontend/src/components/compliance-posture.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CompliancePosture, type ComplianceControl } from "./compliance-posture";
+
+const controls: ComplianceControl[] = [
+  { id: "secrets", name: "Secret scanning", status: "pass" },
+  { id: "vulns", name: "Dependency vulnerabilities", status: "pass" },
+  { id: "regulatory", name: "Regulatory controls", status: "pending" },
+];
+
+describe("CompliancePosture", () => {
+  it("renders every control name", () => {
+    render(<CompliancePosture controls={controls} />);
+    expect(screen.getByText("Secret scanning")).toBeInTheDocument();
+    expect(screen.getByText("Dependency vulnerabilities")).toBeInTheDocument();
+    expect(screen.getByText("Regulatory controls")).toBeInTheDocument();
+  });
+
+  it("summarizes how many controls are green", () => {
+    render(<CompliancePosture controls={controls} />);
+    expect(
+      screen.getByLabelText("2 of 3 controls green"),
+    ).toBeInTheDocument();
+  });
+
+  it("labels passing controls with a pass badge", () => {
+    render(<CompliancePosture controls={controls} />);
+    expect(screen.getAllByRole("status", { name: "Pass" }).length).toBe(2);
+  });
+
+  it("labels pending controls as pending", () => {
+    render(<CompliancePosture controls={controls} />);
+    expect(screen.getAllByRole("status", { name: "Pending" }).length).toBe(1);
+  });
+
+  it("reports zero green when nothing passed yet", () => {
+    render(
+      <CompliancePosture
+        controls={[
+          { id: "a", name: "Secret scanning", status: "pending" },
+          { id: "b", name: "Regulatory controls", status: "pending" },
+        ]}
+      />,
+    );
+    expect(screen.getByLabelText("0 of 2 controls green")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/compliance-posture.tsx
+++ b/frontend/src/components/compliance-posture.tsx
@@ -1,0 +1,53 @@
+export type ControlStatus = "pass" | "pending";
+
+export type ComplianceControl = {
+  id: string;
+  name: string;
+  status: ControlStatus;
+};
+
+const CONTROL_LABEL: Record<ControlStatus, string> = {
+  pass: "Pass",
+  pending: "Pending",
+};
+
+type CompliancePostureProps = {
+  controls: readonly ComplianceControl[];
+};
+
+export function CompliancePosture({ controls }: CompliancePostureProps) {
+  const green = controls.filter((control) => control.status === "pass").length;
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
+      <h3 className="text-lg font-semibold text-white">Compliance posture</h3>
+      <p
+        className="mt-2 text-sm text-slate-400"
+        aria-label={`${green} of ${controls.length} controls green`}
+      >
+        {green} of {controls.length} controls green — shift-left by default.
+      </p>
+      <ul className="mt-4 space-y-3">
+        {controls.map((control) => (
+          <li
+            key={control.id}
+            className="flex items-center justify-between rounded-lg border border-white/10 bg-slate-900 px-4 py-2.5"
+          >
+            <span className="text-sm text-slate-200">{control.name}</span>
+            <span
+              role="status"
+              aria-label={CONTROL_LABEL[control.status]}
+              className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${
+                control.status === "pass"
+                  ? "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+                  : "border-amber-400/30 bg-amber-400/10 text-amber-300"
+              }`}
+            >
+              {CONTROL_LABEL[control.status]}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/components/delivery-dashboard.test.tsx
+++ b/frontend/src/components/delivery-dashboard.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DeliveryDashboard } from "./delivery-dashboard";
+
+const healthy = {
+  gates: {
+    lint: "pass" as const,
+    test: "pass" as const,
+    build: "pass" as const,
+    compliance: "pass" as const,
+  },
+  train: {
+    featuresReady: 3,
+    featuresTotal: 3,
+    gateHealth: {
+      lint: "pass" as const,
+      test: "pass" as const,
+      build: "pass" as const,
+      compliance: "pass" as const,
+    },
+    daysUntilTrain: 5,
+  },
+};
+
+describe("DeliveryDashboard", () => {
+  it("labels the train as on schedule when everything is green", () => {
+    render(<DeliveryDashboard {...healthy} />);
+    expect(screen.getByRole("status", { name: /on schedule/i })).toBeInTheDocument();
+  });
+
+  it("renders one gate row per quality gate with the aggregated outcome", () => {
+    render(<DeliveryDashboard {...healthy} />);
+    for (const gate of ["lint", "test", "build", "compliance"]) {
+      expect(screen.getByText(gate)).toBeInTheDocument();
+    }
+    expect(screen.getAllByText("Pass").length).toBe(4);
+  });
+
+  it("shows the feature-readiness and time-to-train counters", () => {
+    render(<DeliveryDashboard {...healthy} />);
+    expect(screen.getByText("3 of 3")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("reports no blockers when gates pass", () => {
+    render(<DeliveryDashboard {...healthy} />);
+    expect(screen.getByText(/no blockers/i)).toBeInTheDocument();
+  });
+
+  it("flips to at-risk and lists the blocked gate when a gate fails", () => {
+    render(
+      <DeliveryDashboard
+        gates={{ ...healthy.gates, compliance: "fail" }}
+        train={{
+          ...healthy.train,
+          gateHealth: { ...healthy.train.gateHealth, compliance: "fail" },
+        }}
+      />,
+    );
+    expect(screen.getByRole("status", { name: /at risk/i })).toBeInTheDocument();
+    expect(screen.getByText(/blocked by: compliance/i)).toBeInTheDocument();
+  });
+
+  it("labels the train as slipped after the boarding date passes with features outstanding", () => {
+    render(
+      <DeliveryDashboard
+        {...healthy}
+        train={{ ...healthy.train, featuresReady: 2, daysUntilTrain: 0 }}
+      />,
+    );
+    expect(screen.getByRole("status", { name: /slipped/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/delivery-dashboard.tsx
+++ b/frontend/src/components/delivery-dashboard.tsx
@@ -1,0 +1,108 @@
+import {
+  ALL_GATES,
+  aggregateGate,
+  assessTrainReadiness,
+  blockedGates,
+  type GateSnapshot,
+  type GateState,
+  type TrainReadiness,
+  type TrainReadinessInput,
+} from "@/lib/delivery";
+
+const READINESS_LABEL: Record<TrainReadiness, string> = {
+  "on-schedule": "On schedule",
+  "at-risk": "At risk",
+  slipped: "Slipped",
+};
+
+const GATE_LABEL: Record<GateState, string> = {
+  pass: "Pass",
+  fail: "Fail",
+  pending: "Pending",
+};
+
+type DeliveryDashboardProps = {
+  gates: GateSnapshot;
+  train: TrainReadinessInput;
+};
+
+export function DeliveryDashboard({ gates, train }: DeliveryDashboardProps) {
+  const overall = aggregateGate(gates);
+  const readiness = assessTrainReadiness(train);
+  const blocked = blockedGates(train.gateHealth);
+
+  return (
+    <section className="w-full max-w-5xl space-y-8">
+      <div className="flex items-center gap-3">
+        <h2 className="text-2xl font-semibold text-white">Delivery dashboard</h2>
+        <span
+          role="status"
+          aria-label={READINESS_LABEL[readiness]}
+          className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-medium text-cyan-300"
+        >
+          {READINESS_LABEL[readiness]}
+        </span>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
+          <h3 className="text-lg font-semibold text-white">
+            Quality gates ({overall})
+          </h3>
+          <ul className="mt-4 space-y-3">
+            {ALL_GATES.map((name) => {
+              const state = gates[name] ?? "pending";
+              return (
+                <li
+                  key={name}
+                  className="flex items-center justify-between rounded-lg border border-white/10 bg-slate-900 px-4 py-2.5"
+                >
+                  <span className="text-sm text-slate-200">{name}</span>
+                  <span
+                    role="status"
+                    className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${
+                      state === "pass"
+                        ? "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+                        : state === "fail"
+                          ? "border-rose-400/30 bg-rose-400/10 text-rose-300"
+                          : "border-amber-400/30 bg-amber-400/10 text-amber-300"
+                    }`}
+                  >
+                    {GATE_LABEL[state]}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+
+        <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
+          <h3 className="text-lg font-semibold text-white">Next train</h3>
+          <dl className="mt-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <dt className="text-sm text-slate-400">Features ready</dt>
+              <dd className="text-sm font-medium text-slate-100">
+                {train.featuresReady} of {train.featuresTotal}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-sm text-slate-400">Days until boarding</dt>
+              <dd className="text-sm font-medium text-slate-100">
+                {train.daysUntilTrain}
+              </dd>
+            </div>
+          </dl>
+          {blocked.length > 0 ? (
+            <p className="mt-4 rounded-lg border border-rose-400/20 bg-rose-400/10 px-4 py-2.5 text-sm text-rose-200">
+              Blocked by: {blocked.join(", ")}
+            </p>
+          ) : (
+            <p className="mt-4 rounded-lg border border-emerald-400/20 bg-emerald-400/10 px-4 py-2.5 text-sm text-emerald-200">
+              No blockers — features can board on time.
+            </p>
+          )}
+        </section>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/feature-status-card.test.tsx
+++ b/frontend/src/components/feature-status-card.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FeatureStatusCard } from "./feature-status-card";
+
+describe("FeatureStatusCard", () => {
+  it("renders the feature name and description", () => {
+    render(
+      <FeatureStatusCard
+        name="Live verify target"
+        description="Curls the deployed URL after promotion."
+        rank="ready"
+      />,
+    );
+    expect(screen.getByText("Live verify target")).toBeInTheDocument();
+    expect(screen.getByText(/curls the deployed url/i)).toBeInTheDocument();
+  });
+
+  it("labels each rank correctly", () => {
+    const { rerender } = render(
+      <FeatureStatusCard name="a" description="d" rank="ready" />,
+    );
+    expect(screen.getByRole("status", { name: "Ready" })).toBeInTheDocument();
+
+    rerender(<FeatureStatusCard name="a" description="d" rank="in-flight" />);
+    expect(screen.getByRole("status", { name: "In flight" })).toBeInTheDocument();
+
+    rerender(<FeatureStatusCard name="a" description="d" rank="blocked" />);
+    expect(screen.getByRole("status", { name: "Blocked" })).toBeInTheDocument();
+  });
+
+  it("shows the boarding train when provided", () => {
+    render(
+      <FeatureStatusCard
+        name="a"
+        description="d"
+        rank="ready"
+        train={2}
+      />,
+    );
+    expect(screen.getByText("Train 2")).toBeInTheDocument();
+  });
+
+  it("omits the train chip when no train is assigned", () => {
+    render(<FeatureStatusCard name="a" description="d" rank="ready" />);
+    expect(screen.queryByText(/train/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/feature-status-card.tsx
+++ b/frontend/src/components/feature-status-card.tsx
@@ -1,0 +1,50 @@
+export type FeatureRank = "ready" | "in-flight" | "blocked";
+
+export type FeatureStatusCardProps = {
+  name: string;
+  description: string;
+  rank: FeatureRank;
+  train?: number;
+};
+
+const RANK_LABEL: Record<FeatureRank, string> = {
+  ready: "Ready",
+  "in-flight": "In flight",
+  blocked: "Blocked",
+};
+
+const RANK_ACCENT: Record<FeatureRank, string> = {
+  ready: "border-emerald-400/30 bg-emerald-400/10 text-emerald-300",
+  "in-flight": "border-cyan-400/30 bg-cyan-400/10 text-cyan-300",
+  blocked: "border-rose-400/30 bg-rose-400/10 text-rose-300",
+};
+
+export function FeatureStatusCard({
+  name,
+  description,
+  rank,
+  train,
+}: FeatureStatusCardProps) {
+  return (
+    <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
+      <div className="flex items-center justify-between gap-4">
+        <h4 className="text-base font-semibold text-white">{name}</h4>
+        <div className="flex items-center gap-2">
+          {train !== undefined ? (
+            <span className="rounded-full border border-white/15 px-2.5 py-0.5 text-[11px] text-slate-400">
+              Train {train}
+            </span>
+          ) : null}
+          <span
+            role="status"
+            aria-label={RANK_LABEL[rank]}
+            className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${RANK_ACCENT[rank]}`}
+          >
+            {RANK_LABEL[rank]}
+          </span>
+        </div>
+      </div>
+      <p className="mt-3 text-sm leading-6 text-slate-400">{description}</p>
+    </section>
+  );
+}

--- a/frontend/src/components/hero.tsx
+++ b/frontend/src/components/hero.tsx
@@ -41,6 +41,12 @@ export function Hero() {
           >
             Try the simulator
           </a>
+          <a
+            href="/dashboard"
+            className="rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-slate-200 transition-colors hover:border-white/30"
+          >
+            Open the dashboard
+          </a>
         </div>
       </div>
     </header>

--- a/frontend/src/lib/delivery.test.ts
+++ b/frontend/src/lib/delivery.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { isReadyForRelease } from "./delivery";
+import {
+  aggregateGate,
+  assessTrainReadiness,
+  blockedGates,
+  isReadyForRelease,
+} from "./delivery";
 
 describe("isReadyForRelease", () => {
   describe("positive scenarios", () => {
@@ -39,5 +44,99 @@ describe("isReadyForRelease", () => {
       };
       expect(isReadyForRelease(gates)).toBe(false);
     });
+  });
+});
+
+describe("aggregateGate", () => {
+  it("is pass when every gate passed", () => {
+    const gates = { lint: "pass", test: "pass", build: "pass", compliance: "pass" } as const;
+    expect(aggregateGate(gates)).toBe("pass");
+  });
+
+  it("is fail when any gate failed", () => {
+    const gates = { lint: "pass", test: "fail", build: "pass", compliance: "pass" } as const;
+    expect(aggregateGate(gates)).toBe("fail");
+  });
+
+  it("is pending when a gate is pending", () => {
+    const gates = { lint: "pass", test: "pending", build: "pass", compliance: "pass" } as const;
+    expect(aggregateGate(gates)).toBe("pending");
+  });
+
+  it("is pending when a gate is missing", () => {
+    expect(aggregateGate({ lint: "pass", test: "pass", build: "pass" })).toBe(
+      "pending",
+    );
+  });
+});
+
+describe("assessTrainReadiness", () => {
+  const healthy = {
+    featuresReady: 3,
+    featuresTotal: 3,
+    gateHealth: {
+      lint: "pass",
+      test: "pass",
+      build: "pass",
+      compliance: "pass",
+    } as const,
+    daysUntilTrain: 5,
+  };
+
+  it("is on-schedule when gates pass, features ready, and the train is ahead", () => {
+    expect(assessTrainReadiness(healthy)).toBe("on-schedule");
+  });
+
+  it("is on-schedule when features are still boarding but gates pass", () => {
+    const boarding = { ...healthy, featuresReady: 2, featuresTotal: 3 };
+    expect(assessTrainReadiness(boarding)).toBe("on-schedule");
+  });
+
+  it("is at-risk when any gate failed", () => {
+    const blocked = {
+      ...healthy,
+      gateHealth: { ...healthy.gateHealth, compliance: "fail" },
+    } as const;
+    expect(assessTrainReadiness(blocked)).toBe("at-risk");
+  });
+
+  it("is at-risk while a gate is still pending", () => {
+    const pending = {
+      ...healthy,
+      gateHealth: { ...healthy.gateHealth, build: "pending" },
+    } as const;
+    expect(assessTrainReadiness(pending)).toBe("at-risk");
+  });
+
+  it("is slipped when the train date passed without every feature ready", () => {
+    const missed: typeof healthy = { ...healthy, featuresReady: 2, daysUntilTrain: 0 };
+    expect(assessTrainReadiness(missed)).toBe("slipped");
+  });
+
+  it("is still on-schedule on the train date when everything is ready", () => {
+    const onDate: typeof healthy = { ...healthy, daysUntilTrain: 0 };
+    expect(assessTrainReadiness(onDate)).toBe("on-schedule");
+  });
+
+  it("handles an empty feature set as ready", () => {
+    const empty = { ...healthy, featuresReady: 0, featuresTotal: 0 };
+    expect(assessTrainReadiness(empty)).toBe("on-schedule");
+  });
+});
+
+describe("blockedGates", () => {
+  it("returns the failing gates only", () => {
+    const gates = { lint: "pass", test: "fail", build: "pass", compliance: "fail" } as const;
+    expect(blockedGates(gates)).toEqual(["test", "compliance"]);
+  });
+
+  it("returns no gates when everything passes", () => {
+    const gates = { lint: "pass", test: "pass", build: "pass", compliance: "pass" } as const;
+    expect(blockedGates(gates)).toEqual([]);
+  });
+
+  it("ignores pending gates", () => {
+    const gates = { lint: "pass", test: "pending", build: "pass", compliance: "pass" } as const;
+    expect(blockedGates(gates)).toEqual([]);
   });
 });

--- a/frontend/src/lib/delivery.ts
+++ b/frontend/src/lib/delivery.ts
@@ -7,3 +7,45 @@ export function isReadyForRelease(
 ): boolean {
   return ALL_GATES.every((name) => gates[name] === true);
 }
+
+export type GateState = "pass" | "fail" | "pending";
+
+export type GateSnapshot = Partial<Record<GateName, GateState>>;
+
+export function aggregateGate(gates: GateSnapshot): GateState {
+  const states = ALL_GATES.map((name) => gates[name]);
+  if (states.includes("fail")) return "fail";
+  if (states.includes("pending") || states.includes(undefined)) {
+    return "pending";
+  }
+  return "pass";
+}
+
+export type TrainReadiness = "on-schedule" | "at-risk" | "slipped";
+
+export type TrainReadinessInput = {
+  featuresReady: number;
+  featuresTotal: number;
+  gateHealth: GateSnapshot;
+  daysUntilTrain: number;
+};
+
+export function assessTrainReadiness(input: TrainReadinessInput): TrainReadiness {
+  const failedGate = ALL_GATES.some((name) => input.gateHealth[name] === "fail");
+  const pendingGate = ALL_GATES.some(
+    (name) =>
+      input.gateHealth[name] === "pending" || input.gateHealth[name] === undefined,
+  );
+  const allFeaturesReady =
+    input.featuresTotal === 0 || input.featuresReady >= input.featuresTotal;
+
+  if (failedGate || pendingGate) return "at-risk";
+  if (input.daysUntilTrain <= 0) {
+    return allFeaturesReady ? "on-schedule" : "slipped";
+  }
+  return "on-schedule";
+}
+
+export function blockedGates(gates: GateSnapshot): GateName[] {
+  return ALL_GATES.filter((name) => gates[name] === "fail");
+}


### PR DESCRIPTION
Phase 9 (Product Surface) — T9.1/T9.2/T9.3, issues #55-#57. frontend/ only, per the phases 9-10 parallelization plan (docs/plans/phases-9-10-parallelization.md).

- **T9.2** src/lib/delivery.ts: GateSnapshot, aggregateGate, assessTrainReadiness, blockedGates — release-train/readiness model (TDD, domain tests)
- **T9.1** /dashboard route + DeliveryDashboard component consuming the model (TDD), hero link
- **T9.3** CompliancePosture + FeatureStatusCard components (TDD)

All 61 frontend tests green; make lint green (no workflow drift).