### PR TITLE
feat(release-pipeline): real rollback record + controlled failure-drill kit

### DIFF
--- a/.github/pdm/workflows/release-pipeline.yml
+++ b/.github/pdm/workflows/release-pipeline.yml
@@ -357,6 +357,32 @@ jobs:
           EOF
           echo "Recorded rollback to ${ROLLBACK_TO}"
 
+      - name: Record real rollback deployment
+        if: needs.build.outputs.real_deploy == 'true'
+        env:
+          TARGET_ENV: ${{ inputs.environment || 'all' }}
+          ROLLBACK_TO: ${{ inputs.rollback_to }}
+        uses: actions/github-script@v9
+        with:
+          # A real-mode rollback is a first-class delivery event: it creates a
+          # Deployment API record for the rollback target so the recovery shows
+          # up in the native audit trail (delivery telemetry's MTTR proxy reads
+          # "failure event -> next deployment"). The controlled T10.2 drill
+          # files its one labeled incident between the broken deploy and this
+          # recovery record.
+          script: |
+            const envName = process.env.TARGET_ENV;
+            const resp = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.ROLLBACK_TO,
+              environment: envName,
+              auto_merge: false,
+              required_contexts: [],
+              description: 'rollback recovery deployment',
+            });
+            console.log(`Created rollback deployment ${resp.data.id} for ${envName} at ${process.env.ROLLBACK_TO}.`);
+
       - name: Upload rollback record
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -357,6 +357,32 @@ jobs:
           EOF
           echo "Recorded rollback to ${ROLLBACK_TO}"
 
+      - name: Record real rollback deployment
+        if: needs.build.outputs.real_deploy == 'true'
+        env:
+          TARGET_ENV: ${{ inputs.environment || 'all' }}
+          ROLLBACK_TO: ${{ inputs.rollback_to }}
+        uses: actions/github-script@v9
+        with:
+          # A real-mode rollback is a first-class delivery event: it creates a
+          # Deployment API record for the rollback target so the recovery shows
+          # up in the native audit trail (delivery telemetry's MTTR proxy reads
+          # "failure event -> next deployment"). The controlled T10.2 drill
+          # files its one labeled incident between the broken deploy and this
+          # recovery record.
+          script: |
+            const envName = process.env.TARGET_ENV;
+            const resp = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.ROLLBACK_TO,
+              environment: envName,
+              auto_merge: false,
+              required_contexts: [],
+              description: 'rollback recovery deployment',
+            });
+            console.log(`Created rollback deployment ${resp.data.id} for ${envName} at ${process.env.ROLLBACK_TO}.`);
+
       - name: Upload rollback record
         uses: actions/upload-artifact@v4
         with:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,7 +80,8 @@ deploy-production    (approval via required_reviewers)
 - `environment` input selects the chain: `development` (dev only), `staging` (staging, then production), `production` (production only), `all` (full chain, default).
 - A push to `main` is always a real deployment (`real_deploy=true`, calls `createDeployment`). A `workflow_dispatch` run defaults to `dry_run: true`, which writes `deploy-<env>.md` records and uploads them as artifacts without touching the Deployment API.
 - Each environment job runs a post-deploy verify step: if `DEPLOY_VERIFY_URL` is set it curls the URL (failing the job on a non-200 response); otherwise verification is skipped.
-- `rollback_to` records a dry-run rollback event (`rollback.md`, uploaded as `rollback-record` artifact) — no API call, useful for planning and audit.
+- `rollback_to` writes a dry-run rollback event (`rollback.md`, uploaded as `rollback-record` artifact). When the run is real (`dry_run: false` / push), the rollback job additionally creates a Deployment API record for the `rollback_to` ref — the native recovery event that telemetry's MTTR proxy reads (see `docs/train-failure-drill.md`).
+- The controlled recovery drill (T10.2) uses this path on `development` only: deploy the `chore/phase10-failure-drill` SHA (contains `scripts/train-drill-marker.mjs`), file one `incident`-labeled issue, then recover with a real `rollback_to` dispatch; `delivery-telemetry` then computes real CFR and MTTR.
 
 ## Release on tag and security re-scan
 

--- a/docs/local-runbook.md
+++ b/docs/local-runbook.md
@@ -94,6 +94,10 @@ GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=frdrpo/learning-pdm-fintech-de
   LOOKBACK_DAYS=90 node scripts/delivery-telemetry.mjs /tmp/telemetry
 ```
 
+## Failure & recovery drill (T10.2)
+
+The controlled drill that gives CFR/MTTR real data is fully documented in `docs/train-failure-drill.md`. In short: dispatch `release-pipeline` at the drill branch (`dry_run=false, environment=development`) → file the **one** `incident`-labeled issue → recover with a real-mode `rollback_to` dispatch → run `delivery-telemetry` to read the computed CFR and MTTR. The rollback job records a real Deployment API event when `dry_run=false`, so the recovery is a native record.
+
 ## Where results land
 
 | Event | Results |
@@ -101,6 +105,7 @@ GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=frdrpo/learning-pdm-fintech-de
 | PR run | PR comments (risk report, compliance pass/fail, gate summary) |
 | Non-PR run (`workflow_dispatch`, push, schedule) | Run artifacts: `risk-report`, `gate-report`, `security-rescan-report`, `delivery-telemetry`, `release-train-simulation`, `deploy-record-<env>`, `rollback-record`, `release-notes`, `build-info` — download from the run's "Artifacts" section |
 | Dry-run release | `deploy-<env>.md` records written under `.github/pdm/deployments/` in the job workspace, uploaded as artifacts (never committed) |
+| Rollback (real mode) | Native Deployment API record for `rollback_to` (the recovery event MTTR reads), plus the `rollback-record` artifact |
 
 ## Troubleshooting
 
@@ -119,3 +124,4 @@ GITHUB_TOKEN="$(gh auth token)" GITHUB_REPOSITORY=frdrpo/learning-pdm-fintech-de
 | `delivery-telemetry` metrics report `insufficient-data` | Expected on fresh repos or pure dry-run activity — telemetry reads GitHub-native API records only (ADR 0008); real deployments / rollback or incident issues populate it. |
 | Simulator run "did nothing" to delivery metrics | Expected — the simulator creates labeled artifacts only (ADR 0010); it never writes to the native delivery records telemetry reads. |
 | One comment per push on an active PR | Expected — the PR workflows re-run on every `synchronize`. |
+| `delivery-telemetry` CFR/MTTR still `insufficient-data` after the drill | The drill issue must carry the `incident` (or `rollback`) **label** — telemetry counts failures by label, never title (see `docs/train-failure-drill.md`); MTTR also needs a deployment *after* the incident. |

--- a/docs/train-failure-drill.md
+++ b/docs/train-failure-drill.md
@@ -1,0 +1,76 @@
+# T10.2 — Controlled Failure & Recovery Drill (runbook)
+
+P10-T2 files **one** carefully-labeled issue so `delivery-telemetry.mjs` computes a real Change Failure Rate and Time-to-Recovery proxy from native GitHub records. This is a **controlled drill on a lower environment only** — never staging/production.
+
+## Vehicles
+
+| Thing | Where | Purpose |
+|---|---|---|
+| Regression marker | `scripts/train-drill-marker.mjs` | The deliberately-introduced regression. Lives in `scripts/` (Track B's zone) so the drill never touches `frontend/` or the live verify target. With `DRILL_BREAK=1` it reports a degraded health signal and exits 1. |
+| Broken deploy target | branch `chore/phase10-failure-drill` | A pushable SHA that carries the marker — the ref you deploy first. It is **never** PR'd/merged to `develop`. |
+| Good deploy target | `develop` (or `main`) HEAD | The recovery/rollback target. |
+| Recovery record | `release-pipeline.yml` rollback job | In real mode the rollback job now creates a Deployment API record for `rollback_to` — the native "recovery deployment" that MTTR reads. |
+
+## Label discipline (non-negotiable)
+
+- Exactly **one** issue is filed: it carries the **`incident`** label (equivalently `rollback`). That is the failure event.
+- No other issue or PR in the chapter may carry `rollback` / `incident` / `outage` / `hotfix` / `regression` **labels**. (Title text is irrelevant — `delivery-telemetry.mjs` counts by label only, never by title, so feature PRs that merely mention "rollback" cannot pollute CFR.)
+- The drill is a real failure event: it is *real and explained*, never padded or hidden. Close the incident issue after recovery; closing keeps the label, and the record stays in the window.
+
+## Execute the drill
+
+Prereqs: `gh auth login`; the drill branch pushed (see below); confirm `development` has no reviewer protection (staging/production do).
+
+1. **Confirm the vehicles are on origin.**
+   ```sh
+   git ls-remote origin chore/phase10-failure-drill
+   ```
+
+2. **Deploy the broken version** (real Deployment API record for the drill SHA):
+   ```sh
+   gh workflow run release-pipeline.yml --ref chore/phase10-failure-drill \
+     -f dry_run=false -f environment=development
+   gh run watch $(gh run list --workflow=release-pipeline.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+   ```
+   The `deploy-development` job records a real `createDeployment` for the drill SHA. Save that SHA — it is the failure's `from`.
+
+3. **File the one labeled incident issue** (the failure event):
+   ```sh
+   gh issue create --label incident \
+     --title "OPS drill: controlled failure on development (train failure recovery)" \
+     --body "Controlled T10.2 recovery drill. Deployed drill SHA \`<drill-sha>\` (contains scripts/train-drill-marker.mjs with DRILL_BREAK=1) to development; recovery via release-pipeline rollback_to to the good SHA. Recorded for CFR/MTTR — real and explained."
+   ```
+   Note the issue number and `created_at` — MTTR measures from this event to the next deployment.
+
+4. **Recover via `rollback_to`** (real record of the good SHA):
+   ```sh
+   GOOD_SHA=$(git -C . rev-parse origin/develop)
+   gh workflow run release-pipeline.yml --ref develop \
+     -f dry_run=false -f environment=development -f "rollback_to=${GOOD_SHA}"
+   gh run watch $(gh run list --workflow=release-pipeline.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+   ```
+   This records the recovery: the rollback job creates a Deployment API record for `rollback_to`, and the development deploy records the good SHA.
+
+5. **Truth the telemetry** — CFR and MTTR must now be computed:
+   ```sh
+   gh workflow run delivery-telemetry.yml --ref develop
+   gh run download $(gh run list --workflow=delivery-telemetry.yml --limit 1 --json databaseId --jq '.[0].databaseId') -n delivery-telemetry
+   ```
+   Check `delivery-telemetry-<ts>.md` for `### Change failure rate` and `### Time to recovery (proxy)` with real values, and record the readout in the ROADMAP.
+
+6. **Close the incident** (keeps the label; the failure event remains in the window):
+   ```sh
+   gh issue close <issue-number>
+   ```
+
+## After the drill
+
+- Record the DORA readout (CFR %, MTTR median) in `docs/ROADMAP.md` / the chapter plan.
+- Delete the drill branch when it is no longer needed: `git push origin --delete chore/phase10-failure-drill` (the marker script is kept in git history for future drills).
+
+## Expected outcome
+
+- `delivery-telemetry` audit: the drill deployment, the recovery deployment, and the labeled incident are all present.
+- CFR: computed (failures ÷ deployments in window) — real, explained.
+- MTTR: computed (median failure event → next deployment) — minutes-class for a drill, explained as such.
+- The live verify target (`DEPLOY_VERIFY_URL`) is unaffected — the drill never alters `frontend/`.


### PR DESCRIPTION
T10.2 drill setup (issue #60), Track B zone only — no frontend/.

- rollback job now creates a **Deployment API record** for `rollback_to` when the run is real (`dry_run: false` / push to main) — this is the native recovery event that `delivery-telemetry`'s MTTR proxy reads (ADR 0008 records). Dry-run artifact record kept.
- `docs/train-failure-drill.md`: full runbook — deploy the drill SHA to development, file the **one** `incident`-labeled issue, recover via real `rollback_to`, truth CFR/MTTR, close the incident.
- docs/architecture.md + docs/local-runbook.md updated. `make lint` green (both trees byte-identical).

The regression vehicle (`scripts/train-drill-marker.mjs`) is intentionally NOT in this PR — it exists only on the deployable `chore/phase10-failure-drill` branch so `develop` stays regression-free.