### PR TITLE
chore(ci): sync dependabot actions bumps into canonical

### DIFF
--- a/.github/pdm/workflows/delivery-telemetry.yml
+++ b/.github/pdm/workflows/delivery-telemetry.yml
@@ -41,7 +41,7 @@ jobs:
           ls -la .github/pdm/reports/delivery-*
 
       - name: Upload delivery telemetry & audit trail
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: delivery-telemetry
           path: .github/pdm/reports/delivery-*

--- a/.github/pdm/workflows/publish-pages.yml
+++ b/.github/pdm/workflows/publish-pages.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: steps.detect.outputs.found == 'true'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: frontend/out
 

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload gate report
         if: always() && github.event.pull_request.number == null
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-report
           path: .github/pdm/reports/gate-report.md

--- a/.github/pdm/workflows/release-on-tag.yml
+++ b/.github/pdm/workflows/release-on-tag.yml
@@ -112,7 +112,7 @@ jobs:
             console.log(`Created release ${resp.data.html_url}`);
 
       - name: Upload release notes artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-notes
           path: .github/pdm/releases/release-notes-${{ github.ref_name }}.md

--- a/.github/pdm/workflows/release-pipeline.yml
+++ b/.github/pdm/workflows/release-pipeline.yml
@@ -84,7 +84,7 @@ jobs:
           EOF
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-info
           path: dist/build-info.json
@@ -180,7 +180,7 @@ jobs:
 
       - name: Upload development deployment record
         if: needs.build.outputs.real_deploy == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deploy-record-development
           path: .github/pdm/deployments/deploy-development.md
@@ -252,7 +252,7 @@ jobs:
 
       - name: Upload staging deployment record
         if: needs.build.outputs.real_deploy == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deploy-record-staging
           path: .github/pdm/deployments/deploy-staging.md
@@ -324,7 +324,7 @@ jobs:
 
       - name: Upload production deployment record
         if: needs.build.outputs.real_deploy == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deploy-record-production
           path: .github/pdm/deployments/deploy-production.md
@@ -384,7 +384,7 @@ jobs:
             console.log(`Created rollback deployment ${resp.data.id} for ${envName} at ${process.env.ROLLBACK_TO}.`);
 
       - name: Upload rollback record
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rollback-record
           path: .github/pdm/deployments/rollback.md

--- a/.github/pdm/workflows/release-train-simulator.yml
+++ b/.github/pdm/workflows/release-train-simulator.yml
@@ -45,7 +45,7 @@ jobs:
           ls -la .github/pdm/reports/release-train-simulation-*
 
       - name: Upload simulation report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-train-simulation
           path: .github/pdm/reports/release-train-simulation-*

--- a/.github/pdm/workflows/risk-health-check.yml
+++ b/.github/pdm/workflows/risk-health-check.yml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Upload risk report
         if: always() && github.event.pull_request.number == null
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: risk-report
           path: .github/pdm/reports/risk-report.md

--- a/.github/pdm/workflows/security-rescan.yml
+++ b/.github/pdm/workflows/security-rescan.yml
@@ -77,7 +77,7 @@ jobs:
           echo "Wrote ${report_file}"
 
       - name: Upload re-scan report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: security-rescan-report
           path: .github/pdm/reports/security-rescan-*.md


### PR DESCRIPTION
Adopts the actions bumps merged in dependabot PRs #92 and #93 into `.github/pdm/workflows` (make sync-deps + make sync; lint clean).