### PR TITLE
chore(ci): sync dependabot actions bumps (2nd batch) into canonical

### DIFF
--- a/.github/pdm/workflows/publish-pages.yml
+++ b/.github/pdm/workflows/publish-pages.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Set up pnpm
         if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.21.0
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: Configure Pages
         if: steps.detect.outputs.found == 'true'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
         if: steps.detect.outputs.found == 'true'
@@ -90,4 +90,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Set up pnpm
         if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.21.0
 

--- a/.github/pdm/workflows/release-on-tag.yml
+++ b/.github/pdm/workflows/release-on-tag.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Set up pnpm
         if: steps.stack.outputs.found == 'true' && hashFiles('frontend/pnpm-lock.yaml') != ''
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.21.0
 

--- a/.github/pdm/workflows/release-pipeline.yml
+++ b/.github/pdm/workflows/release-pipeline.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set up pnpm
         if: steps.stack.outputs.found == 'true' && hashFiles('frontend/pnpm-lock.yaml') != ''
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.21.0
 

--- a/.github/pdm/workflows/risk-health-check.yml
+++ b/.github/pdm/workflows/risk-health-check.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Set up pnpm
         if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 11.21.0
 


### PR DESCRIPTION
Adopts configure-pages 5-6, deploy-pages 4-5, pnpm/action-setup 4-6 (PRs #94-#96) into \`.github/pdm/workflows\` via make sync-deps + make sync; lint clean.