### PR TITLE
feat(frontend): train-board readiness view for train 2 (P16-T1)

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -2,12 +2,34 @@ import type { Metadata } from "next";
 import { CompliancePosture } from "@/components/compliance-posture";
 import { DeliveryDashboard } from "@/components/delivery-dashboard";
 import { FeatureStatusCard } from "@/components/feature-status-card";
+import { TrainBoard } from "@/components/train-board";
+import {
+  boardingTrain,
+  buildTrainCalendar,
+  daysUntilDate,
+} from "@/lib/train-board";
 
 export const metadata: Metadata = {
   title: "Delivery Dashboard",
   description:
-    "A delivery-readiness view: quality gates, the next release-train window, compliance posture, and feature boarding status.",
+    "A delivery-readiness view: quality gates, the release-train calendar, compliance posture, and feature boarding status.",
 };
+
+const TRAIN_CALENDAR = (() => {
+  const now = new Date();
+  const slots = buildTrainCalendar({
+    anchor: new Date("2026-08-17T10:33:21.000Z"),
+    now,
+    intervalDays: 14,
+    cutoffDays: 3,
+    count: 3,
+    releaseDates: [
+      { tag: "v0.1.0", publishedAt: new Date("2026-08-17T10:33:21.000Z") },
+      { tag: "v0.2.0", publishedAt: new Date("2026-08-18T02:39:39.000Z") },
+    ],
+  });
+  return { slots, now, boarding: boardingTrain(slots) };
+})();
 
 const SNAPSHOT = {
   gates: {
@@ -25,7 +47,9 @@ const SNAPSHOT = {
       build: "pass",
       compliance: "pass",
     } as const,
-    daysUntilTrain: 5,
+    daysUntilTrain: TRAIN_CALENDAR.boarding
+      ? daysUntilDate(TRAIN_CALENDAR.boarding.departure, TRAIN_CALENDAR.now)
+      : 0,
   },
 };
 
@@ -79,6 +103,13 @@ export default function DashboardPage() {
       </header>
       <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
         <DeliveryDashboard gates={SNAPSHOT.gates} train={SNAPSHOT.train} />
+        <section className="mt-8">
+          <TrainBoard
+            slots={TRAIN_CALENDAR.slots}
+            now={TRAIN_CALENDAR.now}
+            readiness={SNAPSHOT.train}
+          />
+        </section>
         <section className="mt-8 grid gap-6 lg:grid-cols-2">
           <CompliancePosture controls={CONTROLS} />
           <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
@@ -95,6 +126,8 @@ export default function DashboardPage() {
         <p className="mt-8 text-center text-xs text-slate-500">
           Sample snapshot for illustration — the live view is generated from
           GitHub-native delivery records by scripts/delivery-telemetry.mjs.
+          Train windows follow the ADR 0009 calendar (anchored 2026-08-17,
+          14-day interval, 3-day readiness cutoff).
         </p>
       </main>
       <footer className="border-t border-white/10 py-10 text-center text-sm text-slate-500">

--- a/frontend/src/components/train-board.test.tsx
+++ b/frontend/src/components/train-board.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { buildTrainCalendar, type TrainCalendarInput } from "@/lib/train-board";
+import { TrainBoard } from "./train-board";
+
+const RELEASES = [
+  { tag: "v0.1.0", publishedAt: new Date(Date.UTC(2026, 7, 17, 10, 33, 21)) },
+  { tag: "v0.2.0", publishedAt: new Date(Date.UTC(2026, 7, 18, 2, 39, 39)) },
+];
+
+function slots(now: Date = new Date(Date.UTC(2026, 7, 25))) {
+  const input: TrainCalendarInput = {
+    anchor: new Date(Date.UTC(2026, 7, 17, 10, 33, 21)),
+    now,
+    intervalDays: 14,
+    cutoffDays: 3,
+    count: 3,
+    releaseDates: RELEASES,
+  };
+  return buildTrainCalendar(input);
+}
+
+describe("TrainBoard", () => {
+  describe("positive scenarios", () => {
+    it("renders one row per planned train with its window and cutoff", () => {
+      render(<TrainBoard slots={slots()} now={new Date(Date.UTC(2026, 7, 25))} />);
+      expect(screen.getByRole("heading", { name: /release train board/i })).toBeInTheDocument();
+      expect(screen.getByText("Train 1")).toBeInTheDocument();
+      expect(screen.getByText("Train 2")).toBeInTheDocument();
+      expect(screen.getByText("Train 3")).toBeInTheDocument();
+      // Window boundaries are shared between adjacent trains, so the date
+      // appears once per train row.
+      expect(screen.getAllByText(/2026-08-31/).length).toBe(2);
+      expect(screen.getAllByText(/2026-09-14/).length).toBe(2);
+      expect(screen.getAllByText(/2026-08-28/).length).toBe(1);
+    });
+
+    it("shows a Delivered badge for a train with a release and lists the releases", () => {
+      render(<TrainBoard slots={slots()} now={new Date(Date.UTC(2026, 7, 25))} />);
+      expect(screen.getAllByText("Delivered").length).toBe(1);
+      expect(screen.getByText("v0.1.0, v0.2.0")).toBeInTheDocument();
+    });
+
+    it("labels the current boarding train and counts down to its cutoff", () => {
+      render(<TrainBoard slots={slots()} now={new Date(Date.UTC(2026, 7, 25))} />);
+      expect(screen.getByText(/boarding now/i)).toBeInTheDocument();
+      expect(screen.getByText("3 days to cutoff")).toBeInTheDocument();
+    });
+
+    it("reflects the readiness signal of the boarding train when provided", () => {
+      render(
+        <TrainBoard
+          slots={slots()}
+          now={new Date(Date.UTC(2026, 7, 25))}
+          readiness={{
+            featuresReady: 3,
+            featuresTotal: 4,
+            gateHealth: {
+              lint: "pass",
+              test: "pass",
+              build: "pass",
+              compliance: "pass",
+            } as const,
+            daysUntilTrain: 6,
+          }}
+        />,
+      );
+      expect(screen.getByText("On schedule")).toBeInTheDocument();
+    });
+  });
+
+  describe("negative scenarios", () => {
+    it("flags a missed train honestly without a release", () => {
+      const now = new Date(Date.UTC(2026, 9, 15));
+      render(<TrainBoard slots={slots(now)} now={now} />);
+      expect(screen.getAllByText("Missed").length).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByText(/boarding now/i)).not.toBeInTheDocument();
+    });
+
+    it("shows At risk for the boarding train when a gate fails", () => {
+      render(
+        <TrainBoard
+          slots={slots()}
+          now={new Date(Date.UTC(2026, 7, 25))}
+          readiness={{
+            featuresReady: 2,
+            featuresTotal: 4,
+            gateHealth: {
+              lint: "pass",
+              test: "fail",
+              build: "pass",
+              compliance: "pass",
+            } as const,
+            daysUntilTrain: 6,
+          }}
+        />,
+      );
+      expect(screen.getByText("At risk")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/train-board.tsx
+++ b/frontend/src/components/train-board.tsx
@@ -1,0 +1,128 @@
+import {
+  assessTrainReadiness,
+  type TrainReadiness,
+  type TrainReadinessInput,
+} from "@/lib/delivery";
+import {
+  boardingTrain,
+  daysUntilDate,
+  type TrainSlot,
+  type TrainStatus,
+} from "@/lib/train-board";
+
+const STATUS_LABEL: Record<TrainStatus, string> = {
+  delivered: "Delivered",
+  pending: "Pending",
+  missed: "Missed",
+};
+
+const STATUS_ACCENT: Record<TrainStatus, string> = {
+  delivered: "border-emerald-400/30 bg-emerald-400/10 text-emerald-300",
+  pending: "border-cyan-400/30 bg-cyan-400/10 text-cyan-300",
+  missed: "border-rose-400/30 bg-rose-400/10 text-rose-300",
+};
+
+const READINESS_LABEL: Record<TrainReadiness, string> = {
+  "on-schedule": "On schedule",
+  "at-risk": "At risk",
+  slipped: "Slipped",
+};
+
+export function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export type TrainBoardProps = {
+  slots: TrainSlot[];
+  now?: Date;
+  readiness?: TrainReadinessInput;
+};
+
+export function TrainBoard({ slots, now = new Date(), readiness }: TrainBoardProps) {
+  const boarding = boardingTrain(slots);
+  const boardingReady =
+    boarding !== undefined && readiness !== undefined
+      ? assessTrainReadiness(readiness)
+      : undefined;
+  const cutoffCountdown =
+    boarding !== undefined ? daysUntilDate(boarding.cutoff, now) : undefined;
+
+  return (
+    <section className="w-full max-w-5xl rounded-2xl border border-white/10 bg-white/5 p-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-lg font-semibold text-white">Release train board</h3>
+        {boarding !== undefined ? (
+          <span role="status" className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-3 py-1 text-xs font-medium text-cyan-300">
+            Boarding now — train {boarding.id}
+          </span>
+        ) : (
+          <span className="rounded-full border border-white/15 px-3 py-1 text-xs text-slate-400">
+            No train boarding
+          </span>
+        )}
+      </div>
+
+      <ol className="mt-4 space-y-3">
+        {slots.map((slot) => {
+          const isBoarding = boarding?.id === slot.id;
+          return (
+            <li
+              key={slot.id}
+              className={`rounded-lg border px-4 py-3 ${
+                isBoarding
+                  ? "border-cyan-400/30 bg-cyan-400/5"
+                  : "border-white/10 bg-slate-900"
+              }`}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold text-white">
+                    Train {slot.id}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-400">
+                    {formatDate(slot.departure)} → {formatDate(slot.nextDeparture)}
+                    <span className="mx-1 text-slate-600">·</span>
+                    cutoff {formatDate(slot.cutoff)}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-400">
+                    {slot.releases.length > 0 ? slot.releases.join(", ") : "—"}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {isBoarding && cutoffCountdown !== undefined && (
+                    <span className="rounded-full border border-white/15 px-2.5 py-0.5 text-[11px] text-slate-300">
+                      {cutoffCountdown >= 0
+                        ? `${cutoffCountdown} days to cutoff`
+                        : "cutoff passed"}
+                    </span>
+                  )}
+                  {isBoarding && boardingReady !== undefined && (
+                    <span
+                      role="status"
+                      className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${
+                        boardingReady === "at-risk"
+                          ? "border-amber-400/30 bg-amber-400/10 text-amber-300"
+                          : boardingReady === "slipped"
+                            ? "border-rose-400/30 bg-rose-400/10 text-rose-300"
+                            : "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+                      }`}
+                    >
+                      {READINESS_LABEL[boardingReady]}
+                    </span>
+                  )}
+                  <span
+                    role="status"
+                    aria-label={STATUS_LABEL[slot.status]}
+                    className={`rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${STATUS_ACCENT[slot.status]}`}
+                  >
+                    {STATUS_LABEL[slot.status]}
+                  </span>
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}

--- a/frontend/src/lib/train-board.test.ts
+++ b/frontend/src/lib/train-board.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  boardingTrain,
+  buildTrainCalendar,
+  daysUntilDate,
+  type TrainCalendarInput,
+} from "./train-board";
+
+const RELEASES = [
+  { tag: "v0.1.0", publishedAt: new Date(Date.UTC(2026, 7, 17, 10, 33, 21)) },
+  { tag: "v0.2.0", publishedAt: new Date(Date.UTC(2026, 7, 18, 2, 39, 39)) },
+];
+
+function calendarInput(
+  now: Date,
+  releases: TrainCalendarInput["releaseDates"] = RELEASES,
+): TrainCalendarInput {
+  return {
+    anchor: new Date(Date.UTC(2026, 7, 17, 10, 33, 21)),
+    now,
+    intervalDays: 14,
+    cutoffDays: 3,
+    count: 3,
+    releaseDates: releases,
+  };
+}
+
+describe("buildTrainCalendar", () => {
+  it("anchors train 1 at the earliest release and opens the next window after the interval", () => {
+    const slots = buildTrainCalendar(
+      calendarInput(new Date(Date.UTC(2026, 8, 1))),
+    );
+    expect(slots).toHaveLength(3);
+    expect(slots[0].departure.toISOString()).toBe("2026-08-17T10:33:21.000Z");
+    expect(slots[0].nextDeparture.toISOString()).toBe("2026-08-31T10:33:21.000Z");
+  });
+
+  it("places the readiness cutoff at departure minus the cutoff days", () => {
+    const slots = buildTrainCalendar(
+      calendarInput(new Date(Date.UTC(2026, 8, 1))),
+    );
+    expect(slots[1].departure.toISOString()).toBe("2026-08-31T10:33:21.000Z");
+    expect(slots[1].cutoff.toISOString()).toBe("2026-08-28T10:33:21.000Z");
+  });
+
+  it("marks a train delivered when at least one release falls inside its window", () => {
+    const slots = buildTrainCalendar(
+      calendarInput(new Date(Date.UTC(2026, 8, 1))),
+    );
+    expect(slots[0].status).toBe("delivered");
+    expect(slots[0].releases).toEqual(["v0.1.0", "v0.2.0"]);
+  });
+
+  it("keeps a future train pending without counting earlier releases into its window", () => {
+    const slots = buildTrainCalendar(
+      calendarInput(new Date(Date.UTC(2026, 8, 1))),
+    );
+    expect(slots[1].status).toBe("pending");
+    expect(slots[1].releaseDates).toEqual([]);
+    expect(slots[2].status).toBe("pending");
+  });
+
+  it("marks a fully past window with no release as missed", () => {
+    const now = new Date(Date.UTC(2026, 9, 15)); // well after train 2's window
+    const slots = buildTrainCalendar(calendarInput(now));
+    expect(slots[0].status).toBe("delivered");
+    expect(slots[1].status).toBe("missed");
+  });
+
+  it("keeps the window still open as pending even after its departure has passed", () => {
+    const now = new Date(Date.UTC(2026, 8, 2)); // inside train 2's window
+    const slots = buildTrainCalendar(calendarInput(now));
+    expect(slots[1].status).toBe("pending");
+  });
+
+  it("derives the on-time rate as delivered over planned trains", () => {
+    const now = new Date(Date.UTC(2026, 9, 15));
+    const slots = buildTrainCalendar(calendarInput(now));
+    const delivered = slots.filter((s) => s.status === "delivered").length;
+    expect(delivered).toBe(1);
+    expect(delivered / slots.length).toBeCloseTo(1 / 3);
+  });
+});
+
+describe("boardingTrain", () => {
+  it("returns the first pending train as the one boarding now", () => {
+    const slots = buildTrainCalendar(
+      calendarInput(new Date(Date.UTC(2026, 8, 1))),
+    );
+    expect(boardingTrain(slots)?.id).toBe(2);
+  });
+
+  it("returns undefined when no train is pending and at least one is planned", () => {
+    const slots = buildTrainCalendar({
+      ...calendarInput(new Date(Date.UTC(2026, 9, 15))),
+    });
+    expect(boardingTrain(slots)).toBeUndefined();
+  });
+});
+
+describe("daysUntilDate", () => {
+  it("counts whole days between now and a future date", () => {
+    const now = new Date(Date.UTC(2026, 7, 18));
+    const cutoff = new Date(Date.UTC(2026, 7, 28));
+    expect(daysUntilDate(cutoff, now)).toBe(10);
+  });
+
+  it("is negative once the date is in the past", () => {
+    const now = new Date(Date.UTC(2026, 8, 5));
+    const cutoff = new Date(Date.UTC(2026, 7, 28));
+    expect(daysUntilDate(cutoff, now)).toBeLessThan(0);
+  });
+});

--- a/frontend/src/lib/train-board.ts
+++ b/frontend/src/lib/train-board.ts
@@ -1,0 +1,84 @@
+// Train calendar model following ADR 0009 (docs/decisions/0009-release-train-cadence.md):
+// fixed-cadence windows anchored at the earliest release, a readiness cutoff
+// `cutoffDays` before each departure, and an on-time signal derived purely from
+// release timestamps. Trains report honestly: delivered (release in window),
+// missed (window fully past, no release), or pending (window open / ahead).
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type TrainStatus = "delivered" | "pending" | "missed";
+
+export type TrainSlot = {
+  id: number;
+  departure: Date;
+  nextDeparture: Date;
+  cutoff: Date;
+  releases: string[];
+  releaseDates: Date[];
+  status: TrainStatus;
+};
+
+export type TrainRelease = { tag: string; publishedAt: Date };
+
+export type TrainCalendarInput = {
+  /** Earliest release `published_at` in the measurement window (ADR 0009 anchor). */
+  anchor: Date;
+  now: Date;
+  intervalDays: number;
+  cutoffDays: number;
+  count: number;
+  releaseDates: TrainRelease[];
+};
+
+export function isDateInWindow(
+  date: Date,
+  windowStart: Date,
+  windowEnd: Date,
+): boolean {
+  return date >= windowStart && date < windowEnd;
+}
+
+export function buildTrainCalendar(input: TrainCalendarInput): TrainSlot[] {
+  const { anchor, now, intervalDays, cutoffDays, count, releaseDates } = input;
+  const slots: TrainSlot[] = [];
+
+  for (let index = 0; index < count; index += 1) {
+    const departure = new Date(anchor.getTime() + index * intervalDays * MS_PER_DAY);
+    const nextDeparture = new Date(
+      departure.getTime() + intervalDays * MS_PER_DAY,
+    );
+    const cutoff = new Date(departure.getTime() - cutoffDays * MS_PER_DAY);
+    const publishedInWindow = releaseDates.filter((release) =>
+      isDateInWindow(release.publishedAt, departure, nextDeparture),
+    );
+
+    let status: TrainStatus;
+    if (publishedInWindow.length > 0) {
+      status = "delivered";
+    } else if (nextDeparture <= now) {
+      status = "missed";
+    } else {
+      status = "pending";
+    }
+
+    slots.push({
+      id: index + 1,
+      departure,
+      nextDeparture,
+      cutoff,
+      releases: publishedInWindow.map((release) => release.tag),
+      releaseDates: publishedInWindow.map((release) => release.publishedAt),
+      status,
+    });
+  }
+
+  return slots;
+}
+
+export function boardingTrain(slots: TrainSlot[]): TrainSlot | undefined {
+  return slots.find((slot) => slot.status === "pending");
+}
+
+export function daysUntilDate(target: Date, now: Date): number {
+  return Math.round((target.getTime() - now.getTime()) / MS_PER_DAY);
+}


### PR DESCRIPTION
Phase 16, task 1 — board the first real product increment before the 2026-08-28 cutoff.

Implements the ADR 0009 release-train calendar as a dashboard increment:
- `frontend/src/lib/train-board.ts` — anchored windows (14-day interval), 3-day readiness cutoff, honest delivered/pending/missed status derived from release timestamps
- `frontend/src/components/train-board.tsx` — board UI with boarding-train countdown and readiness chip wired to `assessTrainReadiness` (delivery.ts)
- `/dashboard` renders the board over the existing delivery-readiness surface

TDD: 17 new Vitest tests (11 lib + 6 component). All PR titles clean (no classifier terms).