### PR TITLE
feat(frontend): delivery-health dashboard from committed telemetry snapshot (P22-T1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules/
 
 AGENTS.md
 .opencode
+
+# Throwaway wiki clone used for wiki-only edits (ADR 0013)
+.wiki-tmp/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The delivery engine is **live and operating at cadence** — Phases 0–21 compl
 - **Latest truthing readout** (P16-T4, 90d window, run 32115287697): deployment frequency dev 1.79/wk · staging/prod 1.56/wk · pages 2.88/wk; lead time median **6m** (11 PRs); change-failure rate **1.0%** (1/100 — the P10-T2 drill event only); MTTR proxy median **7h 15m** (1 event). The P21 close-out telemetry run (32205889156) confirmed the same numbers unchanged. Full readouts and history: see the [wiki ROADMAP](https://github.com/frdrpo/learning-pdm-fintech-delivery-engine/wiki/ROADMAP).
 - **Release train**: 14-day cadence (ADR 0009); train 3 departs **09-14** (cutoff 09-11), train 4 departs 09-28 — see the [Release Train Calendar](https://github.com/frdrpo/learning-pdm-fintech-delivery-engine/wiki/Release-Train-Calendar).
 - **Branch topology**: `develop` (default, integration) + `main` (protected; requires the `PDM Quality Gate (Status Check)`). Feature/track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main`.
+- **Product surface**: the frontend now renders the live delivery telemetry at [`/delivery`](https://frdrpo.github.io/learning-pdm-fintech-delivery-engine/delivery/) — DORA metric cards, the release-train status panel (ADR 0009 window logic), and the audit trail — from a committed, versioned snapshot of the `delivery-telemetry` export (honest `insufficient-data` empty states, never invented numbers).
 
 ## Repository Structure
 
@@ -36,7 +37,7 @@ All PDM workflow and deployment material is consolidated under a single folder, 
 - `.github/pdm/deployments/` - Dry-run deployment records uploaded as run artifacts by the release pipeline (not committed).
 - `.github/pdm/reports/` - Risk and quality-gate reports uploaded as run artifacts (not committed).
 - `.github/workflows/` - Mirrored execution copies of `.github/pdm/workflows/`. GitHub only executes workflows from this directory, so keep the copies in sync with `make sync`.
-- `frontend/` - Next.js 16 website (App Router, TypeScript, Tailwind v4) — a dark fintech landing page with Vitest unit + component tests. This is the application the delivery gates exercise.
+- `frontend/` - Next.js 16 website (App Router, TypeScript, Tailwind v4) — a dark fintech landing page with Vitest unit + component tests, plus a `/delivery` route rendering the live delivery-health snapshot (DORA metrics, release-train status, audit trail). This is the application the delivery gates exercise.
 
 ## System Flow
 

--- a/frontend/src/app/delivery/page.tsx
+++ b/frontend/src/app/delivery/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import { DeliveryHealthPage } from "@/components/delivery-health/delivery-health-page";
+import { PageHeader } from "@/components/page-header";
+import { SiteFooter } from "@/components/site-footer";
+import { loadDeliverySnapshot } from "@/lib/delivery-health/snapshot";
+
+export const metadata: Metadata = {
+  title: "Delivery Health",
+  description:
+    "Live delivery telemetry from GitHub-native records: DORA metrics, the release-train status, and the audit trail.",
+};
+
+export default function DeliveryPage() {
+  const snapshot = loadDeliverySnapshot();
+
+  return (
+    <>
+      <PageHeader
+        title="Delivery health"
+        subtitle="DORA-style delivery telemetry read from GitHub-native records — deployments, releases, merged PRs, and failure events."
+      />
+      <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-12">
+        <DeliveryHealthPage snapshot={snapshot} />
+      </main>
+      <SiteFooter>
+        PDM reference implementation — telemetry is read from real events,
+        never invented.
+      </SiteFooter>
+    </>
+  );
+}

--- a/frontend/src/components/delivery-health/audit-trail-table.test.tsx
+++ b/frontend/src/components/delivery-health/audit-trail-table.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AuditTrailTable } from "./audit-trail-table";
+import type { DeliveryAudit } from "@/lib/delivery-health/types";
+
+function audit(overrides: Partial<DeliveryAudit> = {}): DeliveryAudit {
+  return {
+    generated_at: "2026-08-19T02:47:53.480Z",
+    repository: "frdrpo/learning-pdm-fintech-delivery-engine",
+    lookback_days: 90,
+    window_start: "2026-05-21T02:47:53.480Z",
+    deployments: [
+      {
+        id: 1,
+        environment: "production",
+        ref: "abc123",
+        description: null,
+        created_at: "2026-08-18T08:11:32.000Z",
+      },
+      {
+        id: 2,
+        environment: "development",
+        ref: "def456",
+        description: "dry-run",
+        created_at: "2026-08-18T02:39:39.000Z",
+      },
+    ],
+    releases: [
+      { tag: "v0.3.0", name: "Release v0.3.0", published_at: "2026-08-18T08:11:32.000Z" },
+    ],
+    merged_pulls: [
+      {
+        number: 158,
+        title: "docs(P21): chapter close-out",
+        merge_commit_sha: "f2f1d889",
+        merged_at: "2026-08-19T01:46:50.000Z",
+      },
+    ],
+    failure_events: [
+      {
+        number: 105,
+        title: "OPS drill: controlled failure on development",
+        created_at: "2026-08-18T00:53:47.000Z",
+      },
+    ],
+    release_trains: [
+      { train: 1, planned_departure: "2026-08-17T10:33:21.000Z", delivered: true },
+    ],
+    ...overrides,
+  };
+}
+
+describe("AuditTrailTable", () => {
+  it("renders a row per audit event with its type", () => {
+    render(<AuditTrailTable audit={audit()} />);
+    expect(screen.getAllByText("Deployment").length).toBe(2);
+    expect(screen.getByText("Release")).toBeInTheDocument();
+    expect(screen.getByText("Merged PR")).toBeInTheDocument();
+    expect(screen.getByText("Failure event")).toBeInTheDocument();
+  });
+
+  it("shows the environment and ref for deployments", () => {
+    render(<AuditTrailTable audit={audit()} />);
+    expect(screen.getByText("production")).toBeInTheDocument();
+    expect(screen.getByText("abc123")).toBeInTheDocument();
+  });
+
+  it("shows the release tag", () => {
+    render(<AuditTrailTable audit={audit()} />);
+    expect(screen.getByText("v0.3.0")).toBeInTheDocument();
+  });
+
+  it("shows the merged PR number and title", () => {
+    render(<AuditTrailTable audit={audit()} />);
+    expect(screen.getByText("#158")).toBeInTheDocument();
+    expect(screen.getByText("docs(P21): chapter close-out")).toBeInTheDocument();
+  });
+
+  it("shows the failure event title", () => {
+    render(<AuditTrailTable audit={audit()} />);
+    expect(
+      screen.getByText("OPS drill: controlled failure on development"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an honest empty state when there are no events", () => {
+    render(
+      <AuditTrailTable
+        audit={audit({ deployments: [], releases: [], merged_pulls: [], failure_events: [] })}
+      />,
+    );
+    expect(screen.getByText(/no audit events in this snapshot/i)).toBeInTheDocument();
+  });
+
+  it("caps the visible rows and reports the total", () => {
+    const many = audit({
+      deployments: Array.from({ length: 12 }, (_, i) => ({
+        id: i,
+        environment: "development",
+        ref: `sha${i}`,
+        description: null,
+        created_at: "2026-08-18T08:11:32.000Z",
+      })),
+      releases: [],
+      merged_pulls: [],
+      failure_events: [],
+    });
+    render(<AuditTrailTable audit={many} maxRows={5} />);
+    const rows = screen.getAllByRole("row");
+    // header + 5 visible rows
+    expect(rows).toHaveLength(6);
+    expect(screen.getByText(/12 audit events/)).toBeInTheDocument();
+  });
+
+  it("sorts events newest first", () => {
+    render(<AuditTrailTable audit={audit()} />);
+    const rows = screen.getAllByRole("row");
+    const firstRow = within(rows[1]).getByText("#158");
+    expect(firstRow).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/delivery-health/audit-trail-table.tsx
+++ b/frontend/src/components/delivery-health/audit-trail-table.tsx
@@ -1,0 +1,121 @@
+import { Badge, type BadgeTone } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { formatDate } from "@/lib/delivery-health/format";
+import type { DeliveryAudit } from "@/lib/delivery-health/types";
+
+type AuditEventKind = "deployment" | "release" | "merged-pr" | "failure-event";
+
+type AuditRow = {
+  id: string;
+  kind: AuditEventKind;
+  title: string;
+  detail: string;
+  date: string | null;
+};
+
+const KIND_LABEL: Record<AuditEventKind, string> = {
+  deployment: "Deployment",
+  release: "Release",
+  "merged-pr": "Merged PR",
+  "failure-event": "Failure event",
+};
+
+const KIND_TONE: Record<AuditEventKind, BadgeTone> = {
+  deployment: "cyan",
+  release: "violet",
+  "merged-pr": "neutral",
+  "failure-event": "rose",
+};
+
+function toRows(audit: DeliveryAudit): AuditRow[] {
+  const rows: AuditRow[] = [
+    ...audit.deployments.map((d) => ({
+      id: `deploy-${d.id}`,
+      kind: "deployment" as const,
+      title: d.environment,
+      detail: d.ref,
+      date: d.created_at,
+    })),
+    ...audit.releases.map((r) => ({
+      id: `release-${r.tag}`,
+      kind: "release" as const,
+      title: r.tag,
+      detail: r.name,
+      date: r.published_at,
+    })),
+    ...audit.merged_pulls.map((p) => ({
+      id: `pr-${p.number}`,
+      kind: "merged-pr" as const,
+      title: `#${p.number}`,
+      detail: p.title,
+      date: p.merged_at,
+    })),
+    ...audit.failure_events.map((e) => ({
+      id: `failure-${e.number}`,
+      kind: "failure-event" as const,
+      title: `#${e.number}`,
+      detail: e.title,
+      date: e.created_at,
+    })),
+  ];
+  return rows.sort((a, b) => {
+    const aMs = a.date ? Date.parse(a.date) : 0;
+    const bMs = b.date ? Date.parse(b.date) : 0;
+    return bMs - aMs;
+  });
+}
+
+type AuditTrailTableProps = {
+  audit: DeliveryAudit;
+  maxRows?: number;
+};
+
+export function AuditTrailTable({ audit, maxRows = 10 }: AuditTrailTableProps) {
+  const rows = toRows(audit);
+  const visible = rows.slice(0, maxRows);
+
+  return (
+    <Card as="section">
+      <h3 className="text-lg font-semibold text-white">Audit trail</h3>
+      <p className="mt-2 text-sm text-slate-400">
+        {rows.length} audit events in this snapshot — deployments, releases,
+        merged PRs, and failure events from GitHub-native records.
+      </p>
+      {visible.length === 0 ? (
+        <p className="mt-4 text-sm text-slate-500">
+          No audit events in this snapshot — run scripts/delivery-telemetry.mjs
+          against a repo with real delivery activity.
+        </p>
+      ) : (
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-white/10 text-xs uppercase tracking-wider text-slate-500">
+                <th className="py-2 pr-4">Type</th>
+                <th className="py-2 pr-4">Reference</th>
+                <th className="py-2 pr-4">Detail</th>
+                <th className="py-2">Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((row) => (
+                <tr key={row.id} className="border-b border-white/5">
+                  <td className="py-2.5 pr-4">
+                    <Badge size="sm" tone={KIND_TONE[row.kind]} font="normal">
+                      {KIND_LABEL[row.kind]}
+                    </Badge>
+                  </td>
+                  <td className="py-2.5 pr-4 font-medium text-slate-200">
+                    {row.title}
+                  </td>
+                  <td className="py-2.5 pr-4 text-slate-400">{row.detail}</td>
+                  <td className="py-2.5 text-slate-500">{formatDate(row.date)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/components/delivery-health/delivery-health-page.test.tsx
+++ b/frontend/src/components/delivery-health/delivery-health-page.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DeliveryHealthPage } from "./delivery-health-page";
+import type { DeliverySnapshot } from "@/lib/delivery-health/types";
+
+const NOW = "2026-08-19T02:47:53.000Z";
+
+function snapshot(overrides: Partial<DeliverySnapshot> = {}): DeliverySnapshot {
+  return {
+    kind: "delivery-snapshot",
+    generated_at: "2026-08-19T02:47:53.480Z",
+    repository: "frdrpo/learning-pdm-fintech-delivery-engine",
+    metrics: {
+      generated_at: "2026-08-19T02:47:53.480Z",
+      window: { days: 90, start: "2026-05-21T02:47:53.480Z", end: "2026-08-19T02:47:53.480Z" },
+      counts: { deployments: 100, releases: 3, merged_pulls: 70, failure_events: 1 },
+      deployment_frequency_per_week: {
+        development: { count: 22, per_week: 1.711111111111111 },
+        staging: { count: 21, per_week: 1.6333333333333333 },
+        production: { count: 20, per_week: 1.5555555555555556 },
+      },
+      lead_time_for_changes_hours: { status: "computed", hours: 0.09, prs_sampled: 11 },
+      change_failure_rate: { status: "computed", deployments: 100, failures: 1, ratio: 0.01 },
+      time_to_recovery_hours: { status: "computed", hours: 25.64, events_sampled: 1 },
+      release_train_on_time: {
+        status: "computed",
+        interval_days: 14,
+        anchor_date: "2026-08-17T10:33:21Z",
+        planned_trains: 1,
+        trains_delivered: 1,
+        on_time_rate: 1,
+        missed_train_numbers: [],
+      },
+    },
+    audit: {
+      generated_at: "2026-08-19T02:47:53.480Z",
+      repository: "frdrpo/learning-pdm-fintech-delivery-engine",
+      lookback_days: 90,
+      window_start: "2026-05-21T02:47:53.480Z",
+      deployments: [
+        {
+          id: 1,
+          environment: "production",
+          ref: "abc123",
+          description: null,
+          created_at: "2026-08-18T08:11:32.000Z",
+        },
+      ],
+      releases: [
+        { tag: "v0.3.0", name: "Release v0.3.0", published_at: "2026-08-18T08:11:32.000Z" },
+      ],
+      merged_pulls: [
+        {
+          number: 158,
+          title: "docs(P21): chapter close-out",
+          merge_commit_sha: "f2f1d889",
+          merged_at: "2026-08-19T01:46:50.000Z",
+        },
+      ],
+      failure_events: [],
+      release_trains: [
+        { train: 1, planned_departure: "2026-08-17T10:33:21.000Z", delivered: true },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("DeliveryHealthPage", () => {
+  it("renders the DORA metrics, train status, and audit trail from the snapshot", () => {
+    render(<DeliveryHealthPage snapshot={snapshot()} now={NOW} />);
+    expect(screen.getByText("Deployment frequency")).toBeInTheDocument();
+    expect(screen.getByText("Release train status")).toBeInTheDocument();
+    expect(screen.getByText("Audit trail")).toBeInTheDocument();
+  });
+
+  it("shows the snapshot generation timestamp", () => {
+    render(<DeliveryHealthPage snapshot={snapshot()} now={NOW} />);
+    expect(screen.getByText(/generated 2026-08-19/i)).toBeInTheDocument();
+  });
+
+  it("renders an honest empty state when no snapshot is committed", () => {
+    render(<DeliveryHealthPage snapshot={null} now={NOW} />);
+    expect(screen.getByText(/no delivery snapshot/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/scripts\/delivery-telemetry\.mjs/i),
+    ).toBeInTheDocument();
+  });
+
+  it("flags a stale snapshot without hiding its real data", () => {
+    const stale = snapshot({ generated_at: "2026-05-01T00:00:00.000Z" });
+    render(<DeliveryHealthPage snapshot={stale} now={NOW} />);
+    expect(screen.getByText(/stale/i)).toBeInTheDocument();
+    expect(screen.getByText("Deployment frequency")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/delivery-health/delivery-health-page.tsx
+++ b/frontend/src/components/delivery-health/delivery-health-page.tsx
@@ -1,0 +1,74 @@
+import { AuditTrailTable } from "@/components/delivery-health/audit-trail-table";
+import { DoraMetricsGrid } from "@/components/delivery-health/dora-metrics-grid";
+import { ReleaseTrainPanel } from "@/components/delivery-health/release-train-panel";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { formatDate } from "@/lib/delivery-health/format";
+import { isSnapshotStale } from "@/lib/delivery-health/snapshot";
+import type { DeliverySnapshot } from "@/lib/delivery-health/types";
+
+type DeliveryHealthPageProps = {
+  snapshot: DeliverySnapshot | null;
+  now?: string;
+};
+
+export function DeliveryHealthPage({
+  snapshot,
+  now = new Date().toISOString(),
+}: DeliveryHealthPageProps) {
+  if (!snapshot) {
+    return (
+      <Card as="section">
+        <h2 className="text-2xl font-semibold text-white">
+          Delivery health — no snapshot
+        </h2>
+        <p className="mt-3 text-sm leading-6 text-slate-400">
+          No delivery snapshot is committed in this build. Run{" "}
+          <code className="rounded bg-white/10 px-1.5 py-0.5 text-slate-200">
+            scripts/delivery-telemetry.mjs
+          </code>{" "}
+          against a repo with real delivery activity and commit the export as{" "}
+          <code className="rounded bg-white/10 px-1.5 py-0.5 text-slate-200">
+            frontend/src/lib/delivery-health/delivery-snapshot.json
+          </code>{" "}
+          to populate this page. Numbers are never invented — an absent snapshot
+          renders an explicit empty state.
+        </p>
+      </Card>
+    );
+  }
+
+  const stale = isSnapshotStale(snapshot, 30, new Date(now));
+  const deliveredTrains = snapshot.audit.release_trains
+    .filter((t) => t.delivered)
+    .map((t) => t.train);
+
+  return (
+    <div className="w-full max-w-5xl space-y-8">
+      <div className="flex flex-wrap items-center gap-3">
+        <h2 className="text-2xl font-semibold text-white">Delivery health</h2>
+        {stale ? (
+          <Badge size="md" tone="amber">
+            Stale snapshot
+          </Badge>
+        ) : (
+          <Badge size="md" tone="green">
+            Live snapshot
+          </Badge>
+        )}
+      </div>
+      <p className="text-sm text-slate-400">
+        Generated {formatDate(snapshot.generated_at)} from GitHub-native delivery
+        records — deployments, releases, merged PRs, and failure events.
+      </p>
+
+      <DoraMetricsGrid metrics={snapshot.metrics} />
+      <ReleaseTrainPanel
+        onTime={snapshot.metrics.release_train_on_time}
+        deliveredTrains={deliveredTrains}
+        now={now}
+      />
+      <AuditTrailTable audit={snapshot.audit} />
+    </div>
+  );
+}

--- a/frontend/src/components/delivery-health/dora-metric-card.tsx
+++ b/frontend/src/components/delivery-health/dora-metric-card.tsx
@@ -1,0 +1,35 @@
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+export type DoraMetricCardProps = {
+  label: string;
+  value: string | null;
+  detail: string;
+  windowLabel: string;
+};
+
+export function DoraMetricCard({
+  label,
+  value,
+  detail,
+  windowLabel,
+}: DoraMetricCardProps) {
+  return (
+    <Card as="section">
+      <h3 className="text-sm font-medium uppercase tracking-wider text-slate-400">
+        {label}
+      </h3>
+      {value !== null ? (
+        <p className="mt-3 text-3xl font-semibold text-white">{value}</p>
+      ) : (
+        <div className="mt-3 flex items-center gap-2">
+          <Badge size="sm" tone="amber">
+            Insufficient data
+          </Badge>
+        </div>
+      )}
+      <p className="mt-2 text-sm text-slate-400">{detail}</p>
+      <p className="mt-3 text-xs text-slate-500">Window: {windowLabel}</p>
+    </Card>
+  );
+}

--- a/frontend/src/components/delivery-health/dora-metrics-grid.tsx
+++ b/frontend/src/components/delivery-health/dora-metrics-grid.tsx
@@ -1,0 +1,83 @@
+import { DoraMetricCard } from "@/components/delivery-health/dora-metric-card";
+import { formatHours, formatPercent } from "@/lib/delivery-health/format";
+import type { DeliveryMetrics } from "@/lib/delivery-health/types";
+
+type DoraMetricsGridProps = {
+  metrics: DeliveryMetrics;
+};
+
+function deploymentFrequencyHeadline(
+  metrics: DeliveryMetrics,
+): { value: string | null; detail: string } {
+  const envs = Object.entries(metrics.deployment_frequency_per_week);
+  if (envs.length === 0) {
+    return { value: null, detail: "no deployments recorded in the window" };
+  }
+  const production = envs.find(([name]) => name === "production");
+  const [headlineEnv, headline] = production ?? envs[0];
+  const detail = envs
+    .map(([name, freq]) => `${name}: ${freq.count} deploys (${freq.per_week.toFixed(2)}/wk)`)
+    .join(" · ");
+  return {
+    value: `${headline.per_week.toFixed(1)}/wk`,
+    detail: `${headlineEnv}: ${headline.count} deploys in ${metrics.window.days} days · ${detail}`,
+  };
+}
+
+export function DoraMetricsGrid({ metrics }: DoraMetricsGridProps) {
+  const windowLabel = `last ${metrics.window.days} days`;
+  const frequency = deploymentFrequencyHeadline(metrics);
+
+  const leadTime =
+    metrics.lead_time_for_changes_hours.status === "computed"
+      ? {
+          value: formatHours(metrics.lead_time_for_changes_hours.hours),
+          detail: `median of ${metrics.lead_time_for_changes_hours.prs_sampled} merged PRs`,
+        }
+      : { value: null, detail: metrics.lead_time_for_changes_hours.note };
+
+  const cfr =
+    metrics.change_failure_rate.status === "computed"
+      ? {
+          value: formatPercent(metrics.change_failure_rate.ratio),
+          detail: `${metrics.change_failure_rate.failures} failure event(s) over ${metrics.change_failure_rate.deployments} deployments`,
+        }
+      : { value: null, detail: metrics.change_failure_rate.note };
+
+  const mttr =
+    metrics.time_to_recovery_hours.status === "computed"
+      ? {
+          value: formatHours(metrics.time_to_recovery_hours.hours),
+          detail: `median of ${metrics.time_to_recovery_hours.events_sampled} recovery event(s)`,
+        }
+      : { value: null, detail: metrics.time_to_recovery_hours.note };
+
+  return (
+    <section className="grid gap-6 sm:grid-cols-2">
+      <DoraMetricCard
+        label="Deployment frequency"
+        value={frequency.value}
+        detail={frequency.detail}
+        windowLabel={windowLabel}
+      />
+      <DoraMetricCard
+        label="Lead time for changes"
+        value={leadTime.value}
+        detail={leadTime.detail}
+        windowLabel={windowLabel}
+      />
+      <DoraMetricCard
+        label="Change failure rate"
+        value={cfr.value}
+        detail={cfr.detail}
+        windowLabel={windowLabel}
+      />
+      <DoraMetricCard
+        label="Time to recovery"
+        value={mttr.value}
+        detail={mttr.detail}
+        windowLabel={windowLabel}
+      />
+    </section>
+  );
+}

--- a/frontend/src/components/delivery-health/dora-metrics.test.tsx
+++ b/frontend/src/components/delivery-health/dora-metrics.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DoraMetricCard } from "./dora-metric-card";
+import { DoraMetricsGrid } from "./dora-metrics-grid";
+import type { DeliveryMetrics } from "@/lib/delivery-health/types";
+
+function metrics(overrides: Partial<DeliveryMetrics> = {}): DeliveryMetrics {
+  return {
+    generated_at: "2026-08-19T02:47:53.480Z",
+    window: { days: 90, start: "2026-05-21T02:47:53.480Z", end: "2026-08-19T02:47:53.480Z" },
+    counts: { deployments: 100, releases: 3, merged_pulls: 70, failure_events: 1 },
+    deployment_frequency_per_week: {
+      development: { count: 22, per_week: 1.711111111111111 },
+      staging: { count: 21, per_week: 1.6333333333333333 },
+      production: { count: 20, per_week: 1.5555555555555556 },
+    },
+    lead_time_for_changes_hours: { status: "computed", hours: 0.09, prs_sampled: 11 },
+    change_failure_rate: { status: "computed", deployments: 100, failures: 1, ratio: 0.01 },
+    time_to_recovery_hours: { status: "computed", hours: 25.64, events_sampled: 1 },
+    release_train_on_time: {
+      status: "computed",
+      interval_days: 14,
+      anchor_date: "2026-08-17T10:33:21Z",
+      planned_trains: 1,
+      trains_delivered: 1,
+      on_time_rate: 1,
+      missed_train_numbers: [],
+    },
+    ...overrides,
+  };
+}
+
+describe("DoraMetricCard", () => {
+  it("renders the label, headline value, and detail", () => {
+    render(
+      <DoraMetricCard
+        label="Lead time for changes"
+        value="5m"
+        detail="median of 11 merged PRs"
+        windowLabel="last 90 days"
+      />,
+    );
+    expect(screen.getByText("Lead time for changes")).toBeInTheDocument();
+    expect(screen.getByText("5m")).toBeInTheDocument();
+    expect(screen.getByText("median of 11 merged PRs")).toBeInTheDocument();
+  });
+
+  it("renders an honest insufficient-data state with the note", () => {
+    render(
+      <DoraMetricCard
+        label="Change failure rate"
+        value={null}
+        detail="no failure events in window"
+        windowLabel="last 90 days"
+      />,
+    );
+    expect(screen.getByText("Insufficient data")).toBeInTheDocument();
+    expect(screen.getByText("no failure events in window")).toBeInTheDocument();
+  });
+});
+
+describe("DoraMetricsGrid", () => {
+  it("renders all four DORA metric cards from the snapshot metrics", () => {
+    render(<DoraMetricsGrid metrics={metrics()} />);
+    expect(screen.getByText("Deployment frequency")).toBeInTheDocument();
+    expect(screen.getByText("Lead time for changes")).toBeInTheDocument();
+    expect(screen.getByText("Change failure rate")).toBeInTheDocument();
+    expect(screen.getByText("Time to recovery")).toBeInTheDocument();
+  });
+
+  it("shows the production deployment frequency as the headline", () => {
+    render(<DoraMetricsGrid metrics={metrics()} />);
+    expect(screen.getByText("1.6/wk")).toBeInTheDocument();
+  });
+
+  it("shows the lead time headline in human-readable form", () => {
+    render(<DoraMetricsGrid metrics={metrics()} />);
+    expect(screen.getByText("5m")).toBeInTheDocument();
+  });
+
+  it("shows the change-failure rate as a percentage", () => {
+    render(<DoraMetricsGrid metrics={metrics()} />);
+    expect(screen.getByText("1.0%")).toBeInTheDocument();
+  });
+
+  it("shows the MTTR proxy headline in human-readable form", () => {
+    render(<DoraMetricsGrid metrics={metrics()} />);
+    expect(screen.getByText("1d 1h")).toBeInTheDocument();
+  });
+
+  it("renders insufficient-data cards when metrics are not computed", () => {
+    render(
+      <DoraMetricsGrid
+        metrics={metrics({
+          lead_time_for_changes_hours: {
+            status: "insufficient-data",
+            value: null,
+            note: "no deployment matched a merged PR",
+          },
+          change_failure_rate: {
+            status: "insufficient-data",
+            value: null,
+            note: "no failure events in window",
+          },
+          time_to_recovery_hours: {
+            status: "insufficient-data",
+            value: null,
+            note: "no failure events in window",
+          },
+        })}
+      />,
+    );
+    expect(screen.getAllByText("Insufficient data").length).toBe(3);
+  });
+
+  it("shows the measurement window on every card", () => {
+    render(<DoraMetricsGrid metrics={metrics()} />);
+    expect(screen.getAllByText(/last 90 days/).length).toBe(4);
+  });
+});

--- a/frontend/src/components/delivery-health/release-train-panel.test.tsx
+++ b/frontend/src/components/delivery-health/release-train-panel.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReleaseTrainPanel } from "./release-train-panel";
+import type { ReleaseTrainOnTime } from "@/lib/delivery-health/types";
+
+const ON_TIME: ReleaseTrainOnTime = {
+  status: "computed",
+  interval_days: 14,
+  anchor_date: "2026-08-17T10:33:21Z",
+  planned_trains: 1,
+  trains_delivered: 1,
+  on_time_rate: 1,
+  missed_train_numbers: [],
+};
+
+const NOW = "2026-08-19T02:47:53.000Z";
+
+describe("ReleaseTrainPanel", () => {
+  it("renders the on-time rate headline", () => {
+    render(
+      <ReleaseTrainPanel
+        onTime={ON_TIME}
+        deliveredTrains={[1]}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("100.0%")).toBeInTheDocument();
+    expect(screen.getByText(/1 of 1 planned train/)).toBeInTheDocument();
+  });
+
+  it("lists the departed train as delivered", () => {
+    render(
+      <ReleaseTrainPanel
+        onTime={ON_TIME}
+        deliveredTrains={[1]}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("Train 1")).toBeInTheDocument();
+    expect(screen.getByText("Delivered")).toBeInTheDocument();
+  });
+
+  it("shows the next pending train with its cutoff", () => {
+    render(
+      <ReleaseTrainPanel
+        onTime={ON_TIME}
+        deliveredTrains={[1]}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("Train 2")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.getByText(/cutoff 2026-08-28/)).toBeInTheDocument();
+  });
+
+  it("marks a departed train without a release as missed", () => {
+    render(
+      <ReleaseTrainPanel
+        onTime={{ ...ON_TIME, planned_trains: 2, trains_delivered: 1, on_time_rate: 0.5, missed_train_numbers: [2] }}
+        deliveredTrains={[1]}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("Missed")).toBeInTheDocument();
+    expect(screen.getByText("50.0%")).toBeInTheDocument();
+  });
+
+  it("renders an honest empty state when the on-time signal is insufficient", () => {
+    render(
+      <ReleaseTrainPanel
+        onTime={{
+          status: "insufficient-data",
+          value: null,
+          note: "no releases in window to compare against the train calendar",
+        }}
+        deliveredTrains={[]}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("Insufficient data")).toBeInTheDocument();
+    expect(
+      screen.getByText(/no releases in window to compare/),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/delivery-health/release-train-panel.tsx
+++ b/frontend/src/components/delivery-health/release-train-panel.tsx
@@ -1,0 +1,88 @@
+import { Badge, type BadgeTone } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { formatDate } from "@/lib/delivery-health/format";
+import {
+  buildTrainWindows,
+  type TrainWindowStatus,
+} from "@/lib/delivery-health/train-window";
+import type { ReleaseTrainOnTime } from "@/lib/delivery-health/types";
+
+const STATUS_LABEL: Record<TrainWindowStatus, string> = {
+  delivered: "Delivered",
+  missed: "Missed",
+  pending: "Pending",
+};
+
+const STATUS_TONE: Record<TrainWindowStatus, BadgeTone> = {
+  delivered: "green",
+  missed: "rose",
+  pending: "cyan",
+};
+
+type ReleaseTrainPanelProps = {
+  onTime: ReleaseTrainOnTime;
+  deliveredTrains: number[];
+  now: string;
+};
+
+export function ReleaseTrainPanel({
+  onTime,
+  deliveredTrains,
+  now,
+}: ReleaseTrainPanelProps) {
+  if (onTime.status !== "computed") {
+    return (
+      <Card as="section">
+        <h3 className="text-lg font-semibold text-white">Release train status</h3>
+        <div className="mt-4 flex items-center gap-2">
+          <Badge size="sm" tone="amber">
+            Insufficient data
+          </Badge>
+          <p className="text-sm text-slate-400">{onTime.note}</p>
+        </div>
+      </Card>
+    );
+  }
+
+  const windows = buildTrainWindows({
+    anchorDate: onTime.anchor_date,
+    intervalDays: onTime.interval_days,
+    now,
+    deliveredTrains,
+    plannedTrains: onTime.planned_trains,
+  });
+
+  return (
+    <Card as="section">
+      <h3 className="text-lg font-semibold text-white">Release train status</h3>
+      <p className="mt-2 text-sm text-slate-400">
+        <span className="font-medium text-slate-100">
+          {((onTime.on_time_rate ?? 0) * 100).toFixed(1)}%
+        </span>{" "}
+        on-time — {onTime.trains_delivered} of {onTime.planned_trains} planned
+        train{onTime.planned_trains === 1 ? "" : "s"} shipped on a{" "}
+        {onTime.interval_days}-day cadence anchored {formatDate(onTime.anchor_date)}.
+      </p>
+      <ul className="mt-4 space-y-3">
+        {windows.map((window) => (
+          <li key={window.train}>
+            <Card variant="row">
+              <div>
+                <p className="text-sm font-medium text-slate-200">
+                  Train {window.train}
+                </p>
+                <p className="text-xs text-slate-500">
+                  departs {formatDate(window.departure)} · cutoff{" "}
+                  {formatDate(window.cutoff)}
+                </p>
+              </div>
+              <Badge size="sm" tone={STATUS_TONE[window.status]} label={STATUS_LABEL[window.status]}>
+                {STATUS_LABEL[window.status]}
+              </Badge>
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/frontend/src/components/hero.tsx
+++ b/frontend/src/components/hero.tsx
@@ -47,6 +47,12 @@ export function Hero() {
           >
             Open the dashboard
           </a>
+          <a
+            href="/delivery"
+            className="rounded-full border border-white/15 px-6 py-3 text-sm font-semibold text-slate-200 transition-colors hover:border-white/30"
+          >
+            Delivery health
+          </a>
         </div>
       </div>
     </header>

--- a/frontend/src/lib/delivery-health/delivery-snapshot.json
+++ b/frontend/src/lib/delivery-health/delivery-snapshot.json
@@ -1,0 +1,1223 @@
+{
+  "kind": "delivery-snapshot",
+  "generated_at": "2026-08-19T02:47:53.480Z",
+  "repository": "frdrpo/learning-pdm-fintech-delivery-engine",
+  "metrics": {
+    "generated_at": "2026-08-19T02:47:53.480Z",
+    "window": {
+      "days": 90,
+      "start": "2026-05-21T02:47:53.480Z",
+      "end": "2026-08-19T02:47:53.480Z"
+    },
+    "counts": {
+      "deployments": 100,
+      "releases": 3,
+      "merged_pulls": 70,
+      "failure_events": 1
+    },
+    "deployment_frequency_per_week": {
+      "github-pages": {
+        "count": 37,
+        "per_week": 2.8777777777777778
+      },
+      "staging": {
+        "count": 21,
+        "per_week": 1.6333333333333333
+      },
+      "development": {
+        "count": 22,
+        "per_week": 1.711111111111111
+      },
+      "production": {
+        "count": 20,
+        "per_week": 1.5555555555555556
+      }
+    },
+    "lead_time_for_changes_hours": {
+      "status": "computed",
+      "hours": 0.09055555555555556,
+      "prs_sampled": 11
+    },
+    "change_failure_rate": {
+      "status": "computed",
+      "deployments": 100,
+      "failures": 1,
+      "ratio": 0.01
+    },
+    "time_to_recovery_hours": {
+      "status": "computed",
+      "hours": 25.636666666666667,
+      "events_sampled": 1
+    },
+    "release_train_on_time": {
+      "status": "computed",
+      "interval_days": 14,
+      "anchor_date": "2026-08-17T10:33:21Z",
+      "planned_trains": 1,
+      "trains_delivered": 1,
+      "on_time_rate": 1,
+      "missed_train_numbers": []
+    }
+  },
+  "audit": {
+    "generated_at": "2026-08-19T02:47:53.480Z",
+    "repository": "frdrpo/learning-pdm-fintech-delivery-engine",
+    "lookback_days": 90,
+    "window_start": "2026-05-21T02:47:53.480Z",
+    "deployments": [
+      {
+        "id": 5974904288,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T02:31:59.000Z"
+      },
+      {
+        "id": 5974706791,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T02:13:01.000Z"
+      },
+      {
+        "id": 5974453197,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T01:47:50.000Z"
+      },
+      {
+        "id": 5974402282,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T01:42:18.000Z"
+      },
+      {
+        "id": 5974359360,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T01:37:40.000Z"
+      },
+      {
+        "id": 5974264209,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-19T01:28:40.000Z"
+      },
+      {
+        "id": 5974263797,
+        "environment": "development",
+        "ref": "c44d9cbdb902e02850ef1b3b13588fab6d852926",
+        "description": null,
+        "created_at": "2026-08-19T01:28:37.000Z"
+      },
+      {
+        "id": 5974262664,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-19T01:28:31.000Z"
+      },
+      {
+        "id": 5974185767,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T01:20:13.000Z"
+      },
+      {
+        "id": 5974109810,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T01:12:21.000Z"
+      },
+      {
+        "id": 5973956454,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-19T00:55:46.000Z"
+      },
+      {
+        "id": 5958945268,
+        "environment": "production",
+        "ref": "19f41acacb69456ce07f8c8bc9c0f485af8c092a",
+        "description": null,
+        "created_at": "2026-08-18T08:24:50.000Z"
+      },
+      {
+        "id": 5958942363,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T08:24:37.000Z"
+      },
+      {
+        "id": 5958941570,
+        "environment": "staging",
+        "ref": "19f41acacb69456ce07f8c8bc9c0f485af8c092a",
+        "description": null,
+        "created_at": "2026-08-18T08:24:33.000Z"
+      },
+      {
+        "id": 5958886677,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T08:20:41.000Z"
+      },
+      {
+        "id": 5958885909,
+        "environment": "development",
+        "ref": "19f41acacb69456ce07f8c8bc9c0f485af8c092a",
+        "description": null,
+        "created_at": "2026-08-18T08:20:38.000Z"
+      },
+      {
+        "id": 5958884066,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T08:20:30.000Z"
+      },
+      {
+        "id": 5958861489,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T08:18:54.000Z"
+      },
+      {
+        "id": 5958851332,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T08:18:10.000Z"
+      },
+      {
+        "id": 5958821985,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T08:16:09.000Z"
+      },
+      {
+        "id": 5958789061,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T08:13:56.000Z"
+      },
+      {
+        "id": 5958702680,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T08:08:20.000Z"
+      },
+      {
+        "id": 5958670156,
+        "environment": "production",
+        "ref": "245a9afa45d56aa2d671add0da980bc0e2ebd7f3",
+        "description": null,
+        "created_at": "2026-08-18T08:06:13.000Z"
+      },
+      {
+        "id": 5958643909,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T08:04:16.000Z"
+      },
+      {
+        "id": 5958643270,
+        "environment": "staging",
+        "ref": "245a9afa45d56aa2d671add0da980bc0e2ebd7f3",
+        "description": null,
+        "created_at": "2026-08-18T08:04:13.000Z"
+      },
+      {
+        "id": 5958634503,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T08:03:35.000Z"
+      },
+      {
+        "id": 5958633528,
+        "environment": "development",
+        "ref": "245a9afa45d56aa2d671add0da980bc0e2ebd7f3",
+        "description": null,
+        "created_at": "2026-08-18T08:03:30.000Z"
+      },
+      {
+        "id": 5958631617,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T08:03:21.000Z"
+      },
+      {
+        "id": 5958624873,
+        "environment": "production",
+        "ref": "852e9d562a69fdd7e51fd259e127e629c2984be6",
+        "description": null,
+        "created_at": "2026-08-18T08:02:50.000Z"
+      },
+      {
+        "id": 5958622641,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T08:02:40.000Z"
+      },
+      {
+        "id": 5958621736,
+        "environment": "staging",
+        "ref": "852e9d562a69fdd7e51fd259e127e629c2984be6",
+        "description": null,
+        "created_at": "2026-08-18T08:02:36.000Z"
+      },
+      {
+        "id": 5958331289,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:41:22.000Z"
+      },
+      {
+        "id": 5958274595,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:37:06.000Z"
+      },
+      {
+        "id": 5958224055,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:33:15.000Z"
+      },
+      {
+        "id": 5958195223,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:31:07.000Z"
+      },
+      {
+        "id": 5958110372,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:24:51.000Z"
+      },
+      {
+        "id": 5957979392,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:15:15.000Z"
+      },
+      {
+        "id": 5957909951,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:09:48.000Z"
+      },
+      {
+        "id": 5957807604,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T07:01:43.000Z"
+      },
+      {
+        "id": 5957761421,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T06:58:02.000Z"
+      },
+      {
+        "id": 5957725896,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T06:55:06.000Z"
+      },
+      {
+        "id": 5957652532,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T06:49:05.000Z"
+      },
+      {
+        "id": 5957601136,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T06:44:58.000Z"
+      },
+      {
+        "id": 5957547704,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T06:40:35.000Z"
+      },
+      {
+        "id": 5957538874,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:39:49.000Z"
+      },
+      {
+        "id": 5957538253,
+        "environment": "development",
+        "ref": "852e9d562a69fdd7e51fd259e127e629c2984be6",
+        "description": null,
+        "created_at": "2026-08-18T06:39:45.000Z"
+      },
+      {
+        "id": 5957536532,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:39:37.000Z"
+      },
+      {
+        "id": 5957494500,
+        "environment": "production",
+        "ref": "b290c59fe496fdaaaa99b9acb1be8df6345b778a",
+        "description": null,
+        "created_at": "2026-08-18T06:36:04.000Z"
+      },
+      {
+        "id": 5957491627,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:35:50.000Z"
+      },
+      {
+        "id": 5957491064,
+        "environment": "staging",
+        "ref": "b290c59fe496fdaaaa99b9acb1be8df6345b778a",
+        "description": null,
+        "created_at": "2026-08-18T06:35:47.000Z"
+      },
+      {
+        "id": 5957486043,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T06:35:21.000Z"
+      },
+      {
+        "id": 5957483753,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:35:10.000Z"
+      },
+      {
+        "id": 5957482694,
+        "environment": "development",
+        "ref": "b290c59fe496fdaaaa99b9acb1be8df6345b778a",
+        "description": null,
+        "created_at": "2026-08-18T06:35:05.000Z"
+      },
+      {
+        "id": 5957481108,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:34:58.000Z"
+      },
+      {
+        "id": 5957436931,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T06:31:16.000Z"
+      },
+      {
+        "id": 5957428698,
+        "environment": "production",
+        "ref": "12ea0224f800e2ef8519afe98427436ca924fedb",
+        "description": null,
+        "created_at": "2026-08-18T06:30:38.000Z"
+      },
+      {
+        "id": 5957425459,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:30:22.000Z"
+      },
+      {
+        "id": 5957424695,
+        "environment": "staging",
+        "ref": "12ea0224f800e2ef8519afe98427436ca924fedb",
+        "description": null,
+        "created_at": "2026-08-18T06:30:18.000Z"
+      },
+      {
+        "id": 5957419845,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:29:54.000Z"
+      },
+      {
+        "id": 5957419186,
+        "environment": "development",
+        "ref": "12ea0224f800e2ef8519afe98427436ca924fedb",
+        "description": null,
+        "created_at": "2026-08-18T06:29:50.000Z"
+      },
+      {
+        "id": 5957417807,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T06:29:43.000Z"
+      },
+      {
+        "id": 5956991236,
+        "environment": "production",
+        "ref": "146f956a98db9df258e997a6f1393c132a379d71",
+        "description": null,
+        "created_at": "2026-08-18T05:52:45.000Z"
+      },
+      {
+        "id": 5956947048,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T05:48:31.000Z"
+      },
+      {
+        "id": 5956918071,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T05:45:47.000Z"
+      },
+      {
+        "id": 5956917305,
+        "environment": "staging",
+        "ref": "146f956a98db9df258e997a6f1393c132a379d71",
+        "description": null,
+        "created_at": "2026-08-18T05:45:43.000Z"
+      },
+      {
+        "id": 5956866609,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T05:40:54.000Z"
+      },
+      {
+        "id": 5956865933,
+        "environment": "development",
+        "ref": "146f956a98db9df258e997a6f1393c132a379d71",
+        "description": null,
+        "created_at": "2026-08-18T05:40:50.000Z"
+      },
+      {
+        "id": 5956864270,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T05:40:41.000Z"
+      },
+      {
+        "id": 5956858307,
+        "environment": "production",
+        "ref": "acd0c5a31d44bbd607d907f928e43fab621171f2",
+        "description": null,
+        "created_at": "2026-08-18T05:40:08.000Z"
+      },
+      {
+        "id": 5956830446,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T05:37:18.000Z"
+      },
+      {
+        "id": 5956821748,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T05:36:26.000Z"
+      },
+      {
+        "id": 5956821307,
+        "environment": "staging",
+        "ref": "acd0c5a31d44bbd607d907f928e43fab621171f2",
+        "description": null,
+        "created_at": "2026-08-18T05:36:22.000Z"
+      },
+      {
+        "id": 5956777081,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T05:31:57.000Z"
+      },
+      {
+        "id": 5956773607,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T05:31:38.000Z"
+      },
+      {
+        "id": 5956773263,
+        "environment": "development",
+        "ref": "acd0c5a31d44bbd607d907f928e43fab621171f2",
+        "description": null,
+        "created_at": "2026-08-18T05:31:36.000Z"
+      },
+      {
+        "id": 5956772202,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T05:31:30.000Z"
+      },
+      {
+        "id": 5956739105,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T05:28:26.000Z"
+      },
+      {
+        "id": 5955842643,
+        "environment": "production",
+        "ref": "4b8d31047fc28a504c64f6832150c69280c45a0f",
+        "description": null,
+        "created_at": "2026-08-18T03:59:22.000Z"
+      },
+      {
+        "id": 5955840948,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:59:11.000Z"
+      },
+      {
+        "id": 5955840347,
+        "environment": "staging",
+        "ref": "4b8d31047fc28a504c64f6832150c69280c45a0f",
+        "description": null,
+        "created_at": "2026-08-18T03:59:07.000Z"
+      },
+      {
+        "id": 5955824052,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:57:22.000Z"
+      },
+      {
+        "id": 5955823421,
+        "environment": "development",
+        "ref": "4b8d31047fc28a504c64f6832150c69280c45a0f",
+        "description": null,
+        "created_at": "2026-08-18T03:57:18.000Z"
+      },
+      {
+        "id": 5955822237,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:57:10.000Z"
+      },
+      {
+        "id": 5955765459,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T03:51:06.000Z"
+      },
+      {
+        "id": 5955724187,
+        "environment": "production",
+        "ref": "c0841cb83501b9c4d4ae27fa95966600e41d4f9c",
+        "description": null,
+        "created_at": "2026-08-18T03:46:44.000Z"
+      },
+      {
+        "id": 5955720347,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:46:22.000Z"
+      },
+      {
+        "id": 5955719863,
+        "environment": "staging",
+        "ref": "c0841cb83501b9c4d4ae27fa95966600e41d4f9c",
+        "description": null,
+        "created_at": "2026-08-18T03:46:19.000Z"
+      },
+      {
+        "id": 5955669988,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:41:19.000Z"
+      },
+      {
+        "id": 5955669395,
+        "environment": "development",
+        "ref": "c0841cb83501b9c4d4ae27fa95966600e41d4f9c",
+        "description": null,
+        "created_at": "2026-08-18T03:41:15.000Z"
+      },
+      {
+        "id": 5955668096,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:41:07.000Z"
+      },
+      {
+        "id": 5955652467,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T03:39:27.000Z"
+      },
+      {
+        "id": 5955437116,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T03:18:15.000Z"
+      },
+      {
+        "id": 5955400470,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T03:14:57.000Z"
+      },
+      {
+        "id": 5955359458,
+        "environment": "github-pages",
+        "ref": "develop",
+        "description": null,
+        "created_at": "2026-08-18T03:10:33.000Z"
+      },
+      {
+        "id": 5955337894,
+        "environment": "production",
+        "ref": "155040fc2af36e703ca2d86575881f0f69ae117a",
+        "description": null,
+        "created_at": "2026-08-18T03:08:17.000Z"
+      },
+      {
+        "id": 5955328005,
+        "environment": "production",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:07:14.000Z"
+      },
+      {
+        "id": 5955327441,
+        "environment": "staging",
+        "ref": "155040fc2af36e703ca2d86575881f0f69ae117a",
+        "description": null,
+        "created_at": "2026-08-18T03:07:11.000Z"
+      },
+      {
+        "id": 5955291987,
+        "environment": "staging",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:03:34.000Z"
+      },
+      {
+        "id": 5955291487,
+        "environment": "development",
+        "ref": "155040fc2af36e703ca2d86575881f0f69ae117a",
+        "description": null,
+        "created_at": "2026-08-18T03:03:30.000Z"
+      },
+      {
+        "id": 5955290440,
+        "environment": "development",
+        "ref": "main",
+        "description": null,
+        "created_at": "2026-08-18T03:03:23.000Z"
+      }
+    ],
+    "releases": [
+      {
+        "tag": "v0.3.0",
+        "name": "Release v0.3.0",
+        "published_at": "2026-08-18T08:11:32.000Z"
+      },
+      {
+        "tag": "v0.2.0",
+        "name": "Release v0.2.0",
+        "published_at": "2026-08-18T02:39:39.000Z"
+      },
+      {
+        "tag": "v0.1.0",
+        "name": "Release v0.1.0",
+        "published_at": "2026-08-17T10:33:21.000Z"
+      }
+    ],
+    "merged_pulls": [
+      {
+        "number": 158,
+        "title": "docs(P21): chapter close-out — consistency matrix + ROADMAP status",
+        "merge_commit_sha": "f2f1d8897632723d69861d08df21995eb33a7e37",
+        "merged_at": "2026-08-19T01:46:50.000Z"
+      },
+      {
+        "number": 157,
+        "title": "docs(P20): ADR 0012 docs-home decision + agents-guide mirror sync",
+        "merge_commit_sha": "6eb7028358c756d6abe196e8559de0e3e0e26302",
+        "merged_at": "2026-08-19T01:41:15.000Z"
+      },
+      {
+        "number": 156,
+        "title": "docs(P19): README enhancement & optimization — wiki-wired front door",
+        "merge_commit_sha": "cad5078420131f4adfe9a63b051efe496329f9a4",
+        "merged_at": "2026-08-19T01:35:48.000Z"
+      },
+      {
+        "number": 147,
+        "title": "refactor(frontend): extract UI primitives, page shell, fix lib layering",
+        "merge_commit_sha": "c44d9cbdb902e02850ef1b3b13588fab6d852926",
+        "merged_at": "2026-08-19T01:27:56.000Z"
+      },
+      {
+        "number": 146,
+        "title": "Chore/opencode ollama config",
+        "merge_commit_sha": "7b6a9ac4d56f2fa15a0797900c58368a01a59aae",
+        "merged_at": "2026-08-19T00:54:59.000Z"
+      },
+      {
+        "number": 145,
+        "title": "docs(P18): chapter close-out — Phases 15-18 complete",
+        "merge_commit_sha": "19f41acacb69456ce07f8c8bc9c0f485af8c092a",
+        "merged_at": "2026-08-18T08:19:57.000Z"
+      },
+      {
+        "number": 144,
+        "title": "feat(P16): promote train-2 readiness view to production base",
+        "merge_commit_sha": "245a9afa45d56aa2d671add0da980bc0e2ebd7f3",
+        "merged_at": "2026-08-18T07:59:04.000Z"
+      },
+      {
+        "number": 143,
+        "title": "fix(P16): un-promote train-2 readiness view from main",
+        "merge_commit_sha": "6288e8ad0da71e8ae85c673d919db64b47d2bf84",
+        "merged_at": "2026-08-18T07:08:37.000Z"
+      },
+      {
+        "number": 142,
+        "title": "docs(plan): mark P17-T2/T3 executed and P16-T1 boarded",
+        "merge_commit_sha": "b6533a7c5beba074184adb29a7d310ea66ca819b",
+        "merged_at": "2026-08-18T07:00:53.000Z"
+      },
+      {
+        "number": 141,
+        "title": "docs(P17): record native copy-kit smoke readout",
+        "merge_commit_sha": "6220f266a6e27679dea26dc1a9f2a247a8ba3b66",
+        "merged_at": "2026-08-18T06:57:11.000Z"
+      },
+      {
+        "number": 140,
+        "title": "chore(P17): make topology check runner-token aware",
+        "merge_commit_sha": "24c5832b7e71ea29e13109db830eec87c08fc95d",
+        "merged_at": "2026-08-18T06:54:07.000Z"
+      },
+      {
+        "number": 139,
+        "title": "chore(P17): pass GH_TOKEN to gh in copy-kit smoke",
+        "merge_commit_sha": "7cc7410a5419236c2bee9b0137ebd4f3a8d4ad10",
+        "merged_at": "2026-08-18T06:48:00.000Z"
+      },
+      {
+        "number": 138,
+        "title": "chore(P17): resolve env reviewers from repo owner",
+        "merge_commit_sha": "b931b643e212994e10d3bd88d01064deeb55a5f8",
+        "merged_at": "2026-08-18T06:43:53.000Z"
+      },
+      {
+        "number": 137,
+        "title": "chore(P17): pass GITHUB_REPOSITORY to topology check",
+        "merge_commit_sha": "852e9d562a69fdd7e51fd259e127e629c2984be6",
+        "merged_at": "2026-08-18T06:39:07.000Z"
+      },
+      {
+        "number": 136,
+        "title": "chore(P17): fix copy-kit smoke runner paths",
+        "merge_commit_sha": "b290c59fe496fdaaaa99b9acb1be8df6345b778a",
+        "merged_at": "2026-08-18T06:34:26.000Z"
+      },
+      {
+        "number": 135,
+        "title": "PDM workflow run (feat/p17-copykit-rehearsal)",
+        "merge_commit_sha": "12ea0224f800e2ef8519afe98427436ca924fedb",
+        "merged_at": "2026-08-18T06:29:11.000Z"
+      },
+      {
+        "number": 134,
+        "title": "feat(frontend): train-board readiness view for train 2 (P16-T1)",
+        "merge_commit_sha": "e045ad82924d2ba869c4ff2f5c7312d23b9b0b29",
+        "merged_at": "2026-08-18T05:47:51.000Z"
+      },
+      {
+        "number": 133,
+        "title": "docs(P15): record close-out verification readout",
+        "merge_commit_sha": "146f956a98db9df258e997a6f1393c132a379d71",
+        "merged_at": "2026-08-18T05:36:18.000Z"
+      },
+      {
+        "number": 132,
+        "title": "PDM workflow run (feat/p15-topology-reconcile)",
+        "merge_commit_sha": "acd0c5a31d44bbd607d907f928e43fab621171f2",
+        "merged_at": "2026-08-18T05:30:57.000Z"
+      },
+      {
+        "number": 117,
+        "title": "Promote: simulator plan status fix to main",
+        "merge_commit_sha": "4b8d31047fc28a504c64f6832150c69280c45a0f",
+        "merged_at": "2026-08-18T03:56:35.000Z"
+      },
+      {
+        "number": 116,
+        "title": "docs(plans): mark release-train-simulator chapter complete",
+        "merge_commit_sha": "72ebdb5858d0f21521a41c41914415bd83367d33",
+        "merged_at": "2026-08-18T03:50:32.000Z"
+      },
+      {
+        "number": 115,
+        "title": "Promote: Cadence & Adoption close-out (Phases 12-14) to main",
+        "merge_commit_sha": "c0841cb83501b9c4d4ae27fa95966600e41d4f9c",
+        "merged_at": "2026-08-18T03:40:36.000Z"
+      },
+      {
+        "number": 114,
+        "title": "docs: close out Cadence & Adoption chapter (Phases 12-14)",
+        "merge_commit_sha": "412c99077fcd835dd0109853cc406c4e006184c7",
+        "merged_at": "2026-08-18T03:38:47.000Z"
+      },
+      {
+        "number": 113,
+        "title": "Promote: milestone-gated, self-contained release-on-tag (v0.2.0)",
+        "merge_commit_sha": "155040fc2af36e703ca2d86575881f0f69ae117a",
+        "merged_at": "2026-08-18T03:02:51.000Z"
+      },
+      {
+        "number": 111,
+        "title": "chore(ci): sync dependabot actions bumps (2nd batch) into canonical",
+        "merge_commit_sha": "be8d93d9fbc62a732ba209e26ebe97ba0a2f4b9c",
+        "merged_at": "2026-08-18T01:22:33.000Z"
+      },
+      {
+        "number": 96,
+        "title": "chore(deps): bump actions/configure-pages from 5 to 6",
+        "merge_commit_sha": "94fbc5b27ff3f701f4853875990e4ee7a7ba9303",
+        "merged_at": "2026-08-18T01:21:55.000Z"
+      },
+      {
+        "number": 95,
+        "title": "chore(deps): bump pnpm/action-setup from 4 to 6",
+        "merge_commit_sha": "72cc2257430a54f1bc9306b83324dff735889f16",
+        "merged_at": "2026-08-18T01:21:51.000Z"
+      },
+      {
+        "number": 94,
+        "title": "chore(deps): bump actions/deploy-pages from 4 to 5",
+        "merge_commit_sha": "93d7d1d0523b66b526836a9643b12f4adba18e69",
+        "merged_at": "2026-08-18T01:21:48.000Z"
+      },
+      {
+        "number": 110,
+        "title": "docs(plans): chapter close-out — Phases 9-11 complete",
+        "merge_commit_sha": "e9fefcd497d7767a2e281f36604acf170b54141f",
+        "merged_at": "2026-08-18T01:19:08.000Z"
+      },
+      {
+        "number": 109,
+        "title": "docs(roadmap): Phase 11 truthing readout",
+        "merge_commit_sha": "09c994b853ee638602e6cc38dbab21217e3f4fc3",
+        "merged_at": "2026-08-18T01:17:53.000Z"
+      },
+      {
+        "number": 108,
+        "title": "restore: main parity with develop (Phases 9-10) via protected promotion",
+        "merge_commit_sha": "03ee5dfa27479db848aeffa7ee85a00331f10d70",
+        "merged_at": "2026-08-18T01:09:34.000Z"
+      },
+      {
+        "number": 107,
+        "title": "chore(ci): sync dependabot actions bumps into canonical",
+        "merge_commit_sha": "6797a82b7aad02edd56e18bb61f15047bf5b04d0",
+        "merged_at": "2026-08-18T01:05:52.000Z"
+      },
+      {
+        "number": 93,
+        "title": "chore(deps): bump actions/upload-pages-artifact from 3 to 5",
+        "merge_commit_sha": "6e9a7dd468a6ac289c7745c840c723b702d314b2",
+        "merged_at": "2026-08-18T01:00:52.000Z"
+      },
+      {
+        "number": 92,
+        "title": "chore(deps): bump actions/upload-artifact from 4 to 7",
+        "merge_commit_sha": "c308e04273a284352ced90a4809b3ea651c292a6",
+        "merged_at": "2026-08-18T01:00:44.000Z"
+      },
+      {
+        "number": 106,
+        "title": "docs(roadmap): Phase 9/10 status + T10.2 drill DORA readout",
+        "merge_commit_sha": "439be9bf8bfeb573b1460d3999271fb1da0cb97f",
+        "merged_at": "2026-08-18T00:56:18.000Z"
+      },
+      {
+        "number": 104,
+        "title": "feat(release-pipeline): real rollback record + controlled failure-drill kit",
+        "merge_commit_sha": "3fa3968038a0b96a237dd8c02fd19f39f0398ebb",
+        "merged_at": "2026-08-18T00:46:46.000Z"
+      },
+      {
+        "number": 103,
+        "title": "feat(telemetry): release-train on-time signal + engine summary draft",
+        "merge_commit_sha": "b1a14d150294b2557e0d7e87ae64442c5e18a31c",
+        "merged_at": "2026-08-18T00:40:17.000Z"
+      },
+      {
+        "number": 102,
+        "title": "feat(frontend): delivery dashboard + release-train readiness model",
+        "merge_commit_sha": "c16aa4625838963f9ad5734ae4f624366f24a6cc",
+        "merged_at": "2026-08-18T00:40:13.000Z"
+      },
+      {
+        "number": 101,
+        "title": "docs(plans): phases 9-10 parallelization plan",
+        "merge_commit_sha": "18a4807c995e658b8e67a51e5a5967142d962c7e",
+        "merged_at": "2026-08-18T00:40:09.000Z"
+      },
+      {
+        "number": 91,
+        "title": "docs(frontend): replace create-next-app boilerplate with project-accurate README",
+        "merge_commit_sha": "71adff759ce64595a89b9500011101aa33693cb5",
+        "merged_at": "2026-08-17T11:29:40.000Z"
+      },
+      {
+        "number": 90,
+        "title": "docs(plans): mark Phase 8 complete (maiden voyage first delivery flight)",
+        "merge_commit_sha": "a535b70a03efb4c14ef5ec2d080285f6736d6424",
+        "merged_at": "2026-08-17T11:13:20.000Z"
+      },
+      {
+        "number": 89,
+        "title": "fix(release-on-tag): use github.ref_name in artifact path",
+        "merge_commit_sha": "d8c78dd67f15cdc0b2c0a00c79aaecec0c6ca4aa",
+        "merged_at": "2026-08-17T11:12:39.000Z"
+      },
+      {
+        "number": 88,
+        "title": "fix(release-pipeline): map DEPLOY_VERIFY_URL into verify step env",
+        "merge_commit_sha": "bf48e57e0e0c92865220b8b515c2f50804bc9610",
+        "merged_at": "2026-08-17T11:09:52.000Z"
+      },
+      {
+        "number": 87,
+        "title": "feat(pages): publish static-exported frontend to GitHub Pages for live verify",
+        "merge_commit_sha": "be64aed524bb85142f68535e8d2efde08022cdc4",
+        "merged_at": "2026-08-17T11:03:02.000Z"
+      },
+      {
+        "number": 86,
+        "title": "docs(plans): record P8-T2/T3/T4 completion + baseline DORA readout",
+        "merge_commit_sha": "a31605ed91b8c54536733bdf4053f09de379d00b",
+        "merged_at": "2026-08-17T10:57:38.000Z"
+      },
+      {
+        "number": 85,
+        "title": "fix(telemetry): count failure events by label, not title regex",
+        "merge_commit_sha": "6c330e848a68076f046c418bc6af951f424e162a",
+        "merged_at": "2026-08-17T10:56:14.000Z"
+      },
+      {
+        "number": 84,
+        "title": "P8-T1: Promote develop to main (first real delivery flight)",
+        "merge_commit_sha": "e94d9ef22c28a26e3dcef70de5df1ee5cf3778ff",
+        "merged_at": "2026-08-17T10:01:20.000Z"
+      },
+      {
+        "number": 83,
+        "title": "feat(simulator): headless run mode, workflow, and ADR 0010 (Phase 13)",
+        "merge_commit_sha": "1829cb5087c6164f0c37d7fdc979ef362bf93379",
+        "merged_at": "2026-08-17T09:46:00.000Z"
+      },
+      {
+        "number": 80,
+        "title": "feat(simulator): interactive release-train simulator route (Phase 12)",
+        "merge_commit_sha": "738e8861b8be090581bd73df4c363405364b1af8",
+        "merged_at": "2026-08-17T09:40:45.000Z"
+      },
+      {
+        "number": 78,
+        "title": "feat(simulator): deterministic release-train simulation model (Phase 11)",
+        "merge_commit_sha": "9acd0862e87d40146af9d89493b79e8f3859deb9",
+        "merged_at": "2026-08-17T09:35:04.000Z"
+      },
+      {
+        "number": 76,
+        "title": "docs(adr): reorder decision log into decision order (ADR hygiene)",
+        "merge_commit_sha": "a4834bb23c38b9a2bab336b1526f9440bb12af85",
+        "merged_at": "2026-08-17T09:27:08.000Z"
+      },
+      {
+        "number": 49,
+        "title": "docs(roadmap): mark Phase 7 complete",
+        "merge_commit_sha": "7813984db41899fdbd5d61ab4e3f55a66114998a",
+        "merged_at": "2026-08-17T08:34:35.000Z"
+      },
+      {
+        "number": 47,
+        "title": "Phase 7: delivery telemetry & audit trail",
+        "merge_commit_sha": "036fca5fcd479fa4a71b6a3971dc5cafcaddbfed",
+        "merged_at": "2026-08-17T08:30:14.000Z"
+      },
+      {
+        "number": 46,
+        "title": "feat(frontend): land Next.js app and rewire PDM gates to pnpm",
+        "merge_commit_sha": "828ba9d0d99bfa8f691ce059a299f04a363320c8",
+        "merged_at": "2026-08-17T08:11:02.000Z"
+      },
+      {
+        "number": 44,
+        "title": "docs(runbook): document make sync-deps after dependabot merges",
+        "merge_commit_sha": "eb651566fbc47dbe7dd31abb8f10a99c345978b8",
+        "merged_at": "2026-08-17T07:24:56.000Z"
+      },
+      {
+        "number": 43,
+        "title": "fix(ci): adopt dependabot version bumps into canonical workflows",
+        "merge_commit_sha": "8e94859869ca2a50ae4fd46a116d5ae01ab96ee1",
+        "merged_at": "2026-08-17T07:24:09.000Z"
+      },
+      {
+        "number": 42,
+        "title": "docs(roadmap): mark Phases 3-5 complete and update current state",
+        "merge_commit_sha": "166e02e26497415e1dda9308a8959120deabb6df",
+        "merged_at": "2026-08-17T07:21:08.000Z"
+      },
+      {
+        "number": 41,
+        "title": "fix(ci): sync dependabot version bumps into canonical workflows",
+        "merge_commit_sha": "318673015b79524b574b7be4571a9804b92814ee",
+        "merged_at": "2026-08-17T07:20:15.000Z"
+      },
+      {
+        "number": 39,
+        "title": "chore(deps): bump eslint from 9.39.5 to 10.8.1",
+        "merge_commit_sha": "f7fef7b5f29e169a7fce13f201e757dc095b0fc1",
+        "merged_at": "2026-08-17T07:19:53.000Z"
+      },
+      {
+        "number": 40,
+        "title": "chore(deps): bump actions/download-artifact from 4 to 8",
+        "merge_commit_sha": "79695bc3ffe8465dbecd1809063f93aa702218c0",
+        "merged_at": "2026-08-17T07:19:37.000Z"
+      },
+      {
+        "number": 38,
+        "title": "chore(deps): bump actions/github-script from 7 to 9",
+        "merge_commit_sha": "b8fb19fbadf0e73c17f1402a68ac2a2683df97e6",
+        "merged_at": "2026-08-17T07:19:08.000Z"
+      },
+      {
+        "number": 37,
+        "title": "chore(deps): bump google/osv-scanner-action from 1.8.5 to 2.5.0",
+        "merge_commit_sha": "8926475d2ab30fc967d4654bf5712c94a638e355",
+        "merged_at": "2026-08-17T07:18:39.000Z"
+      },
+      {
+        "number": 36,
+        "title": "chore(deps): bump actions/checkout from 4 to 7",
+        "merge_commit_sha": "3612c5985f467c4ca3dde225c73a2ff37423d91d",
+        "merged_at": "2026-08-17T07:18:15.000Z"
+      },
+      {
+        "number": 35,
+        "title": "chore(deps): bump actions/setup-node from 4 to 7",
+        "merge_commit_sha": "0db19329fb1c4f243ca821d3ab8d1b1255ff0788",
+        "merged_at": "2026-08-17T07:17:56.000Z"
+      },
+      {
+        "number": 32,
+        "title": "Phase 5: Tracked documentation & learning material (architecture, runbook, agent guide, ADRs)",
+        "merge_commit_sha": "b8df67c4361c55c673933fa41f316e3a103bba6b",
+        "merged_at": "2026-08-17T07:16:37.000Z"
+      },
+      {
+        "number": 31,
+        "title": "Phase 4: PDM surface extensions (Dependabot, security re-scan, tag release, rollback, AI risk review)",
+        "merge_commit_sha": "401c624fe1eb0e33bb61295acd1f75f703968115",
+        "merged_at": "2026-08-17T07:16:07.000Z"
+      },
+      {
+        "number": 30,
+        "title": "Feat/remove act remote",
+        "merge_commit_sha": "6bbf1fe5afb9c5719c9027d739a0f6cce1cba579",
+        "merged_at": "2026-08-17T06:47:34.000Z"
+      },
+      {
+        "number": 3,
+        "title": "Phase 0/1: PDM roadmap + verified local harness baseline",
+        "merge_commit_sha": "782426ba6dd0fd32107e3b94db195708b0003f43",
+        "merged_at": "2026-08-17T05:34:43.000Z"
+      },
+      {
+        "number": 2,
+        "title": "Add quality gate and release pipeline; harden security checks",
+        "merge_commit_sha": "1b728d22a92b6d04a16eb94d618da2bbcf5d70df",
+        "merged_at": "2026-08-17T03:00:10.000Z"
+      },
+      {
+        "number": 1,
+        "title": "Add PDM delivery engine workflows and local test tooling",
+        "merge_commit_sha": "96b87a76eefd98cadeda1357571aa1118af56cbb",
+        "merged_at": "2026-08-17T01:22:15.000Z"
+      }
+    ],
+    "failure_events": [
+      {
+        "number": 105,
+        "title": "OPS drill: controlled failure on development (train failure recovery)",
+        "created_at": "2026-08-18T00:53:47.000Z"
+      }
+    ],
+    "release_trains": [
+      {
+        "train": 1,
+        "planned_departure": "2026-08-17T10:33:21.000Z",
+        "delivered": true
+      }
+    ]
+  }
+}

--- a/frontend/src/lib/delivery-health/format.test.ts
+++ b/frontend/src/lib/delivery-health/format.test.ts
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { formatDate, formatHours, formatPercent } from "./format";
+
+describe("formatHours", () => {
+  it("renders minutes for sub-hour values", () => {
+    expect(formatHours(0.09)).toBe("5m");
+  });
+
+  it("renders hours and minutes", () => {
+    expect(formatHours(7.25)).toBe("7h 15m");
+  });
+
+  it("renders days and hours", () => {
+    expect(formatHours(26.5)).toBe("1d 2h");
+  });
+
+  it("renders a whole number of hours", () => {
+    expect(formatHours(3)).toBe("3h 0m");
+  });
+
+  it("renders zero as 0m", () => {
+    expect(formatHours(0)).toBe("0m");
+  });
+});
+
+describe("formatPercent", () => {
+  it("renders a ratio as a one-decimal percentage", () => {
+    expect(formatPercent(0.01)).toBe("1.0%");
+  });
+
+  it("renders 100 percent", () => {
+    expect(formatPercent(1)).toBe("100.0%");
+  });
+
+  it("renders zero percent", () => {
+    expect(formatPercent(0)).toBe("0.0%");
+  });
+});
+
+describe("formatDate", () => {
+  it("renders an ISO timestamp as a short date", () => {
+    expect(formatDate("2026-08-17T10:33:21.000Z")).toBe("2026-08-17");
+  });
+
+  it("renders null as an em dash", () => {
+    expect(formatDate(null)).toBe("—");
+  });
+
+  it("renders an unreadable timestamp as an em dash", () => {
+    expect(formatDate("not-a-date")).toBe("—");
+  });
+});

--- a/frontend/src/lib/delivery-health/format.ts
+++ b/frontend/src/lib/delivery-health/format.ts
@@ -1,0 +1,23 @@
+// Display formatting for the delivery-health dashboard (P23-T2). Mirrors the
+// human-readable conventions of scripts/delivery-telemetry.mjs so the product
+// surface and the run-artifact reports agree on how values are presented.
+
+export function formatHours(hours: number): string {
+  const days = Math.floor(hours / 24);
+  const remainingHours = Math.floor(hours % 24);
+  const minutes = Math.round((hours - days * 24 - remainingHours) * 60);
+  if (days > 0) return `${days}d ${remainingHours}h`;
+  if (remainingHours > 0) return `${remainingHours}h ${minutes}m`;
+  return `${minutes}m`;
+}
+
+export function formatPercent(ratio: number): string {
+  return `${(ratio * 100).toFixed(1)}%`;
+}
+
+export function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toISOString().slice(0, 10);
+}

--- a/frontend/src/lib/delivery-health/snapshot.test.ts
+++ b/frontend/src/lib/delivery-health/snapshot.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  isSnapshotStale,
+  loadDeliverySnapshot,
+  parseDeliverySnapshot,
+} from "./snapshot";
+
+const NOW = new Date("2026-08-19T02:47:53.480Z");
+
+type SnapshotInput = Record<string, unknown> & {
+  kind: string;
+  generated_at: string;
+  repository: string;
+  metrics: Record<string, unknown>;
+  audit?: Record<string, unknown>;
+};
+
+function validInput(): SnapshotInput {
+  return {
+    kind: "delivery-snapshot",
+    generated_at: NOW.toISOString(),
+    repository: "frdrpo/learning-pdm-fintech-delivery-engine",
+    metrics: {
+      generated_at: NOW.toISOString(),
+      window: { days: 90, start: "2026-05-21T02:47:53.480Z", end: NOW.toISOString() },
+      counts: { deployments: 1, releases: 1, merged_pulls: 1, failure_events: 0 },
+      deployment_frequency_per_week: { development: { count: 1, per_week: 0.5 } },
+      lead_time_for_changes_hours: { status: "computed", hours: 0.1, prs_sampled: 2 },
+      change_failure_rate: {
+        status: "insufficient-data",
+        value: null,
+        note: "no failure events in window",
+      },
+      time_to_recovery_hours: {
+        status: "insufficient-data",
+        value: null,
+        note: "no failure events in window",
+      },
+      release_train_on_time: {
+        status: "computed",
+        interval_days: 14,
+        anchor_date: "2026-08-17T10:33:21Z",
+        planned_trains: 1,
+        trains_delivered: 1,
+        on_time_rate: 1,
+        missed_train_numbers: [],
+      },
+    },
+    audit: {
+      generated_at: NOW.toISOString(),
+      repository: "frdrpo/learning-pdm-fintech-delivery-engine",
+      lookback_days: 90,
+      window_start: "2026-05-21T02:47:53.480Z",
+      deployments: [
+        {
+          id: 1,
+          environment: "development",
+          ref: "abc123",
+          description: null,
+          created_at: "2026-08-18T02:39:39.000Z",
+        },
+      ],
+      releases: [],
+      merged_pulls: [],
+      failure_events: [],
+      release_trains: [
+        { train: 1, planned_departure: "2026-08-17T10:33:21Z", delivered: true },
+      ],
+    },
+  };
+}
+
+describe("parseDeliverySnapshot", () => {
+  it("accepts a well-formed snapshot and preserves its labels", () => {
+    const snapshot = parseDeliverySnapshot(validInput());
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.kind).toBe("delivery-snapshot");
+    expect(snapshot?.repository).toContain("frdrpo");
+    expect(snapshot?.generated_at).toBe(NOW.toISOString());
+  });
+
+  it("preserves timestamps from the underlying telemetry export", () => {
+    const snapshot = parseDeliverySnapshot(validInput());
+    expect(snapshot?.metrics.generated_at).toBe(NOW.toISOString());
+    expect(snapshot?.metrics.window.start).toBe("2026-05-21T02:47:53.480Z");
+    expect(snapshot?.audit.generated_at).toBe(NOW.toISOString());
+  });
+
+  it("carries computed and insufficient-data metrics through unchanged", () => {
+    const snapshot = parseDeliverySnapshot(validInput());
+    expect(snapshot?.metrics.lead_time_for_changes_hours.status).toBe("computed");
+    expect(snapshot?.metrics.change_failure_rate.status).toBe("insufficient-data");
+    const cfr = snapshot?.metrics.change_failure_rate as
+      | { status: "insufficient-data"; note: string }
+      | undefined;
+    expect(cfr?.note).toContain("no failure");
+  });
+
+  describe("rejects malformed snapshots (honest empty state, never invented numbers)", () => {
+    it("returns null for null and undefined", () => {
+      expect(parseDeliverySnapshot(null)).toBeNull();
+      expect(parseDeliverySnapshot(undefined)).toBeNull();
+    });
+
+    it("returns null for non-object input", () => {
+      expect(parseDeliverySnapshot("nope")).toBeNull();
+      expect(parseDeliverySnapshot(42)).toBeNull();
+    });
+
+    it("returns null when the kind label is missing or wrong", () => {
+      expect(parseDeliverySnapshot({ ...validInput(), kind: "simulation" })).toBeNull();
+      expect(parseDeliverySnapshot({ ...validInput(), kind: undefined })).toBeNull();
+    });
+
+    it("returns null when metrics are missing", () => {
+      const { metrics: _metrics, ...rest } = validInput();
+      void _metrics;
+      expect(parseDeliverySnapshot(rest)).toBeNull();
+    });
+
+    it("returns null when audit is missing", () => {
+      const input = validInput();
+      delete input.audit;
+      expect(parseDeliverySnapshot(input)).toBeNull();
+    });
+
+    it("returns null when generated_at is not an ISO timestamp", () => {
+      expect(
+        parseDeliverySnapshot({ ...validInput(), generated_at: "yesterday" }),
+      ).toBeNull();
+    });
+  });
+});
+
+describe("loadDeliverySnapshot", () => {
+  it("loads the committed snapshot from the frontend bundle", () => {
+    const snapshot = loadDeliverySnapshot();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.kind).toBe("delivery-snapshot");
+    expect(snapshot?.metrics).toBeDefined();
+    expect(snapshot?.audit).toBeDefined();
+  });
+});
+
+describe("isSnapshotStale", () => {
+  it("is false for a freshly generated snapshot", () => {
+    const snapshot = parseDeliverySnapshot(validInput());
+    expect(isSnapshotStale(snapshot!, 30, NOW)).toBe(false);
+  });
+
+  it("is true when the snapshot predates the maximum age", () => {
+    const snapshot = parseDeliverySnapshot({
+      ...validInput(),
+      generated_at: "2026-05-01T00:00:00.000Z",
+    });
+    expect(isSnapshotStale(snapshot!, 30, NOW)).toBe(true);
+  });
+
+  it("is true when the generated_at timestamp is unreadable", () => {
+    const snapshot = parseDeliverySnapshot(validInput());
+    const withBadDate = { ...snapshot!, generated_at: "not-a-date" };
+    expect(isSnapshotStale(withBadDate, 30, NOW)).toBe(true);
+  });
+});

--- a/frontend/src/lib/delivery-health/snapshot.ts
+++ b/frontend/src/lib/delivery-health/snapshot.ts
@@ -1,0 +1,144 @@
+// Delivery-health data layer (P23-T1). Loads the committed, versioned snapshot
+// (delivery-snapshot.json) at build time — no runtime fetch — and exposes it as
+// typed data. Honesty contract: a missing or malformed snapshot returns null so
+// the UI renders an explicit empty state; every metric carries its own
+// computed / insufficient-data status from the telemetry exporter (ADR 0008).
+
+import snapshotJson from "./delivery-snapshot.json";
+import type {
+  ChangeFailureRate,
+  DeliveryAudit,
+  DeliveryMetrics,
+  DeliverySnapshot,
+  DeploymentFrequencyPerWeek,
+  LeadTimeForChanges,
+  ReleaseTrainOnTime,
+  SnapshotKind,
+  TimeToRecovery,
+} from "./types";
+
+const SNAPSHOT_KIND: SnapshotKind = "delivery-snapshot";
+const ISO_TIMESTAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isIsoTimestamp(value: unknown): value is string {
+  return typeof value === "string" && ISO_TIMESTAMP.test(value);
+}
+
+function isMetric<T>(
+  value: unknown,
+  isComputed: (record: Record<string, unknown>) => boolean,
+): value is Record<string, unknown> & ({ status: "computed" } & T) {
+  if (!isRecord(value)) return false;
+  if (value.status === "computed") return isComputed(value);
+  if (value.status === "insufficient-data") {
+    return value.value === null && typeof value.note === "string";
+  }
+  return false;
+}
+
+const isLeadTime = (r: Record<string, unknown>) =>
+  typeof r.hours === "number" && typeof r.prs_sampled === "number";
+
+const isCfr = (r: Record<string, unknown>) =>
+  typeof r.deployments === "number" &&
+  typeof r.failures === "number" &&
+  typeof r.ratio === "number";
+
+const isMttr = (r: Record<string, unknown>) =>
+  typeof r.hours === "number" && typeof r.events_sampled === "number";
+
+const isOnTime = (r: Record<string, unknown>) =>
+  typeof r.interval_days === "number" &&
+  (r.anchor_date === null || isIsoTimestamp(r.anchor_date)) &&
+  typeof r.planned_trains === "number" &&
+  typeof r.trains_delivered === "number" &&
+  typeof r.on_time_rate === "number" &&
+  Array.isArray(r.missed_train_numbers) &&
+  r.missed_train_numbers.every((n) => typeof n === "number");
+
+function parseDeploymentFrequency(value: unknown): DeploymentFrequencyPerWeek | null {
+  if (!isRecord(value)) return null;
+  const entries = Object.entries(value);
+  const valid = entries.every(
+    ([, v]) =>
+      isRecord(v) && typeof v.count === "number" && typeof v.per_week === "number",
+  );
+  return valid ? (value as DeploymentFrequencyPerWeek) : null;
+}
+
+export function parseDeliverySnapshot(input: unknown): DeliverySnapshot | null {
+  if (!isRecord(input)) return null;
+  if (input.kind !== SNAPSHOT_KIND) return null;
+  if (!isIsoTimestamp(input.generated_at)) return null;
+  if (typeof input.repository !== "string") return null;
+
+  const metrics = input.metrics;
+  if (!isRecord(metrics)) return null;
+  if (!isIsoTimestamp(metrics.generated_at)) return null;
+  if (!isRecord(metrics.window)) return null;
+  if (
+    typeof metrics.window.days !== "number" ||
+    !isIsoTimestamp(metrics.window.start) ||
+    !isIsoTimestamp(metrics.window.end)
+  ) {
+    return null;
+  }
+  const counts = metrics.counts;
+  if (
+    !isRecord(counts) ||
+    typeof counts.deployments !== "number" ||
+    typeof counts.releases !== "number" ||
+    typeof counts.merged_pulls !== "number" ||
+    typeof counts.failure_events !== "number"
+  ) {
+    return null;
+  }
+
+  const deploymentFrequency = parseDeploymentFrequency(
+    metrics.deployment_frequency_per_week,
+  );
+  if (!deploymentFrequency) return null;
+  if (!isMetric<LeadTimeForChanges>(metrics.lead_time_for_changes_hours, isLeadTime)) return null;
+  if (!isMetric<ChangeFailureRate>(metrics.change_failure_rate, isCfr)) return null;
+  if (!isMetric<TimeToRecovery>(metrics.time_to_recovery_hours, isMttr)) return null;
+  if (!isMetric<ReleaseTrainOnTime>(metrics.release_train_on_time, isOnTime)) return null;
+
+  const audit = input.audit;
+  if (!isRecord(audit)) return null;
+  if (!isIsoTimestamp(audit.generated_at)) return null;
+  if (typeof audit.repository !== "string") return null;
+  if (typeof audit.lookback_days !== "number") return null;
+  if (!isIsoTimestamp(audit.window_start)) return null;
+  if (!Array.isArray(audit.deployments)) return null;
+  if (!Array.isArray(audit.releases)) return null;
+  if (!Array.isArray(audit.merged_pulls)) return null;
+  if (!Array.isArray(audit.failure_events)) return null;
+  if (!Array.isArray(audit.release_trains)) return null;
+
+  return {
+    kind: SNAPSHOT_KIND,
+    generated_at: input.generated_at,
+    repository: input.repository,
+    metrics: metrics as unknown as DeliveryMetrics,
+    audit: audit as unknown as DeliveryAudit,
+  };
+}
+
+export function loadDeliverySnapshot(): DeliverySnapshot | null {
+  return parseDeliverySnapshot(snapshotJson);
+}
+
+export function isSnapshotStale(
+  snapshot: DeliverySnapshot,
+  maxAgeDays = 30,
+  now: Date = new Date(),
+): boolean {
+  const generated = Date.parse(snapshot.generated_at);
+  if (Number.isNaN(generated)) return true;
+  const maxAgeMs = maxAgeDays * 24 * 60 * 60 * 1000;
+  return now.getTime() - generated > maxAgeMs;
+}

--- a/frontend/src/lib/delivery-health/train-window.test.ts
+++ b/frontend/src/lib/delivery-health/train-window.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  buildTrainWindows,
+  trainCutoff,
+  type TrainWindowInput,
+} from "./train-window";
+
+const ANCHOR = "2026-08-17T10:33:21.000Z"; // earliest release (train 1 departure)
+const INTERVAL_DAYS = 14;
+const NOW = "2026-08-19T02:47:53.000Z";
+
+function input(overrides: Partial<TrainWindowInput> = {}): TrainWindowInput {
+  return {
+    anchorDate: ANCHOR,
+    intervalDays: INTERVAL_DAYS,
+    now: NOW,
+    deliveredTrains: [1],
+    plannedTrains: 1,
+    cutoffBufferDays: 3,
+    ...overrides,
+  };
+}
+
+describe("trainCutoff", () => {
+  it("subtracts the buffer from the departure date", () => {
+    expect(trainCutoff("2026-08-31T10:33:21.000Z", 3)).toBe(
+      "2026-08-28T10:33:21.000Z",
+    );
+  });
+
+  it("keeps the time-of-day when subtracting the buffer", () => {
+    expect(trainCutoff("2026-09-14T10:33:21.000Z", 3)).toBe(
+      "2026-09-11T10:33:21.000Z",
+    );
+  });
+
+  it("rejects a non-positive buffer", () => {
+    expect(() => trainCutoff("2026-08-31T10:33:21.000Z", 0)).toThrow(RangeError);
+  });
+});
+
+describe("buildTrainWindows", () => {
+  it("builds the departed train plus the next pending train", () => {
+    const windows = buildTrainWindows(input());
+    expect(windows).toHaveLength(2);
+    expect(windows[0]).toMatchObject({
+      train: 1,
+      departure: "2026-08-17T10:33:21.000Z",
+      cutoff: "2026-08-14T10:33:21.000Z",
+      status: "delivered",
+    });
+    expect(windows[1]).toMatchObject({
+      train: 2,
+      departure: "2026-08-31T10:33:21.000Z",
+      cutoff: "2026-08-28T10:33:21.000Z",
+      status: "pending",
+    });
+  });
+
+  it("marks a departed train with no release as missed", () => {
+    const windows = buildTrainWindows(
+      input({ deliveredTrains: [], plannedTrains: 1 }),
+    );
+    expect(windows[0].status).toBe("missed");
+  });
+
+  it("extends the horizon for later planned trains", () => {
+    const windows = buildTrainWindows(
+      input({ deliveredTrains: [1, 3], plannedTrains: 3 }),
+    );
+    expect(windows.map((w) => w.train)).toEqual([1, 2, 3, 4]);
+    expect(windows[0].status).toBe("delivered");
+    expect(windows[1].status).toBe("missed");
+    expect(windows[2].status).toBe("delivered");
+    expect(windows[3].status).toBe("pending");
+  });
+
+  it("derives each window from the anchor plus the interval", () => {
+    const windows = buildTrainWindows(input({ plannedTrains: 2 }));
+    expect(windows[1].departure).toBe("2026-08-31T10:33:21.000Z");
+    expect(windows[2].departure).toBe("2026-09-14T10:33:21.000Z");
+  });
+
+  it("returns an empty list when there is no anchor (insufficient data)", () => {
+    expect(buildTrainWindows(input({ anchorDate: null }))).toEqual([]);
+  });
+
+  it("returns an empty list when the anchor is not a date", () => {
+    expect(buildTrainWindows(input({ anchorDate: "not-a-date" }))).toEqual([]);
+  });
+
+  it("rejects a non-positive interval", () => {
+    expect(() => buildTrainWindows(input({ intervalDays: 0 }))).toThrow(
+      RangeError,
+    );
+  });
+
+  it("rejects a negative planned train count", () => {
+    expect(() => buildTrainWindows(input({ plannedTrains: -1 }))).toThrow(
+      RangeError,
+    );
+  });
+
+  it("labels every window with an ISO departure", () => {
+    for (const window of buildTrainWindows(input({ plannedTrains: 4 }))) {
+      expect(new Date(window.departure).toISOString()).toBe(window.departure);
+    }
+  });
+});

--- a/frontend/src/lib/delivery-health/train-window.ts
+++ b/frontend/src/lib/delivery-health/train-window.ts
@@ -1,0 +1,74 @@
+// ADR 0009 release-train window logic (P23-T2). A train departs every
+// TRAIN_INTERVAL_DAYS from the anchor (the earliest release in the telemetry
+// window); each train's readiness cutoff is departure - CUTOFF_BUFFER_DAYS
+// (default 3, per ADR 0009). A departed train is "delivered" when at least one
+// release published inside its [departure, departure + interval) window, and
+// "missed" otherwise. The next train after the last planned one is "pending".
+
+export type TrainWindowStatus = "delivered" | "missed" | "pending";
+
+export type TrainWindow = {
+  train: number;
+  departure: string;
+  cutoff: string;
+  status: TrainWindowStatus;
+};
+
+export type TrainWindowInput = {
+  anchorDate: string | null;
+  intervalDays: number;
+  now: string;
+  deliveredTrains: number[];
+  plannedTrains: number;
+  cutoffBufferDays?: number;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export function trainCutoff(departureIso: string, bufferDays: number): string {
+  if (!Number.isFinite(bufferDays) || bufferDays <= 0) {
+    throw new RangeError("cutoffBufferDays must be a positive number");
+  }
+  return new Date(new Date(departureIso).getTime() - bufferDays * DAY_MS).toISOString();
+}
+
+export function buildTrainWindows(input: TrainWindowInput): TrainWindow[] {
+  if (!Number.isFinite(input.intervalDays) || input.intervalDays <= 0) {
+    throw new RangeError("intervalDays must be a positive number");
+  }
+  if (!Number.isInteger(input.plannedTrains) || input.plannedTrains < 0) {
+    throw new RangeError("plannedTrains must be a non-negative integer");
+  }
+  if (!input.anchorDate) return [];
+  const anchorMs = Date.parse(input.anchorDate);
+  if (Number.isNaN(anchorMs)) return [];
+
+  const bufferDays = input.cutoffBufferDays ?? 3;
+  const intervalMs = input.intervalDays * DAY_MS;
+  const delivered = new Set(input.deliveredTrains);
+
+  const windows: TrainWindow[] = [];
+  for (let train = 1; train <= input.plannedTrains; train++) {
+    const departure = new Date(anchorMs + (train - 1) * intervalMs).toISOString();
+    windows.push({
+      train,
+      departure,
+      cutoff: trainCutoff(departure, bufferDays),
+      status: delivered.has(train) ? "delivered" : "missed",
+    });
+  }
+
+  // The next train after the last planned one is pending (not yet departed).
+  const nextTrain = input.plannedTrains + 1;
+  const nextDeparture = new Date(
+    anchorMs + (nextTrain - 1) * intervalMs,
+  ).toISOString();
+  windows.push({
+    train: nextTrain,
+    departure: nextDeparture,
+    cutoff: trainCutoff(nextDeparture, bufferDays),
+    status: "pending",
+  });
+
+  return windows;
+}

--- a/frontend/src/lib/delivery-health/types.ts
+++ b/frontend/src/lib/delivery-health/types.ts
@@ -1,0 +1,125 @@
+// Types for the committed delivery-health snapshot (P23). The snapshot mirrors
+// the shape written by scripts/delivery-telemetry.mjs (metrics + audit), wrapped
+// in a self-labeling envelope: kind: "delivery-snapshot" (ADR 0010 labeling
+// ethos) and generated_at preserved so consumers can reason about staleness.
+
+export type SnapshotKind = "delivery-snapshot";
+
+export type InsufficientData = {
+  status: "insufficient-data";
+  value: null;
+  note: string;
+};
+
+export type ComputedMetric<T> = { status: "computed" } & T;
+
+export type MetricResult<T> = ComputedMetric<T> | InsufficientData;
+
+export type LeadTimeForChanges = MetricResult<{
+  hours: number;
+  prs_sampled: number;
+}>;
+
+export type ChangeFailureRate = MetricResult<{
+  deployments: number;
+  failures: number;
+  ratio: number;
+}>;
+
+export type TimeToRecovery = MetricResult<{
+  hours: number;
+  events_sampled: number;
+}>;
+
+export type ReleaseTrainOnTime = MetricResult<{
+  interval_days: number;
+  anchor_date: string | null;
+  planned_trains: number;
+  trains_delivered: number;
+  on_time_rate: number;
+  missed_train_numbers: number[];
+}>;
+
+export type DeploymentFrequency = {
+  count: number;
+  per_week: number;
+};
+
+export type DeploymentFrequencyPerWeek = Record<string, DeploymentFrequency>;
+
+export type MetricsWindow = {
+  days: number;
+  start: string;
+  end: string;
+};
+
+export type MetricsCounts = {
+  deployments: number;
+  releases: number;
+  merged_pulls: number;
+  failure_events: number;
+};
+
+export type DeliveryMetrics = {
+  generated_at: string;
+  window: MetricsWindow;
+  counts: MetricsCounts;
+  deployment_frequency_per_week: DeploymentFrequencyPerWeek;
+  lead_time_for_changes_hours: LeadTimeForChanges;
+  change_failure_rate: ChangeFailureRate;
+  time_to_recovery_hours: TimeToRecovery;
+  release_train_on_time: ReleaseTrainOnTime;
+};
+
+export type DeploymentEvent = {
+  id: number;
+  environment: string;
+  ref: string;
+  description: string | null;
+  created_at: string | null;
+};
+
+export type ReleaseEvent = {
+  tag: string;
+  name: string;
+  published_at: string | null;
+};
+
+export type MergedPull = {
+  number: number;
+  title: string;
+  merge_commit_sha: string;
+  merged_at: string | null;
+};
+
+export type FailureEvent = {
+  number: number;
+  title: string;
+  created_at: string | null;
+};
+
+export type TrainRecord = {
+  train: number;
+  planned_departure: string;
+  delivered: boolean;
+};
+
+export type DeliveryAudit = {
+  generated_at: string;
+  repository: string;
+  lookback_days: number;
+  window_start: string;
+  deployments: DeploymentEvent[];
+  releases: ReleaseEvent[];
+  merged_pulls: MergedPull[];
+  failure_events: FailureEvent[];
+  release_trains: TrainRecord[];
+};
+
+export type DeliverySnapshot = {
+  kind: SnapshotKind;
+  generated_at: string;
+  repository: string;
+  metrics: DeliveryMetrics;
+  audit: DeliveryAudit;
+};


### PR DESCRIPTION
Closes #159 — boards cargo onto train 2 before the 2026-08-28 cutoff.

## Cargo
Small, test-first frontend feature: a delivery-health dashboard (`/delivery`) rendered from a **committed telemetry snapshot** (`frontend/src/lib/delivery-health/delivery-snapshot.json`), including:
- DORA metrics grid (deployment frequency, change lead time, change failure rate)
- Release-train panel (train 1 delivered, train 2 pending with cutoff 2026-08-28)
- Audit trail table (source data provenance: PR titles, issues, deployments, releases)
- Hero link from the home page + README product-surface bullet

No workflow or release-mechanics changes. No secrets/artifacts committed.

## Verification (local, all green)
- `make test-frontend` — install + lint + typecheck + test + build ✓ (123 tests across 14 files)
- `make lint` — actionlint + drift check ✓
- Snapshot data is real repo telemetry (90-day window, generated_at 2026-08-19T02:47:53.480Z)

## Gates
The three PR gates (`quality-gate`, `risk-health-check`, `compliance-guardrail`) only trigger on PRs to `main`; native verification runs via `make test-gh` (PR to main) — see the linked PR.