### PR TITLE
feat(workflows): git-flow PR model — PRs target develop; main only vi…

### DIFF
--- a/.github/pdm/workflows/compliance-guardrail.yml
+++ b/.github/pdm/workflows/compliance-guardrail.yml
@@ -5,7 +5,7 @@ name: PDM Compliance & Security Guardrail
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ develop, main ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -5,7 +5,7 @@ name: PDM Quality Gate (Status Check)
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ develop, main ]
     types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
 

--- a/.github/pdm/workflows/release-on-tag.yml
+++ b/.github/pdm/workflows/release-on-tag.yml
@@ -1,17 +1,20 @@
 name: PDM Release on Tag
 
 # Docs: architecture map, ADRs, and runbook live on the wiki (see the Architecture page).
-# Releases are gated on a closed GitHub milestone titled v<version> and are
-# self-contained: GITHUB_TOKEN-created tags/commits never spawn a new workflow
-# run, so the dispatch path does the whole release (bump + build + createRelease)
-# in one run instead of chaining on a tag push.
+# A version release is a PR to main. The dispatch path is the release cut: it
+# validates the version, enforces the closed-milestone gate (auto-creating the
+# milestone as open if missing), bumps frontend/package.json on develop, and
+# opens (or updates) the release PR develop -> main titled Release v<version>.
+# Merging that PR pushes main, which triggers release-pipeline for real; tagging
+# main with v<version> publishes the GitHub Release via the push-tag path below.
+# GITHUB_TOKEN-created tags/commits never spawn a new workflow run, so the cut
+# (dispatch -> PR) and the publish (tag push) stay explicit, human steps.
 #
 # Paths:
-#   - workflow_dispatch (version input): validates, gates on the milestone
-#     (auto-creates it as open if missing), bumps frontend/package.json on
-#     develop, then builds and creates the GitHub Release in the same run.
-#   - push of a v* tag: still gated on a closed milestone before publishing
-#     (manual tag pushes cannot bypass the gate).
+#   - workflow_dispatch (version input): validates, gates on the milestone,
+#     bumps frontend/package.json on develop, and opens the release PR to main.
+#   - push of a v* tag: builds and creates the GitHub Release, still gated on a
+#     closed milestone (manual tag pushes cannot bypass the gate).
 
 on:
   push:
@@ -31,16 +34,18 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
-  cut-and-tag:
-    name: Cut release (bump develop + tag)
+  cut-release-pr:
+    name: Cut release PR (bump develop + open PR to main)
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.validate.outputs.version }}
       tag: ${{ steps.validate.outputs.tag }}
       sha: ${{ steps.bump.outputs.sha }}
+      pr_url: ${{ steps.open-pr.outputs.url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -125,6 +130,30 @@ jobs:
           fi
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Open release PR to main
+        id: open-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          PR_BODY="Release cut by the PDM delivery engine (milestone-gated).
+
+          - version: v${{ steps.validate.outputs.version }}
+          - milestone: ${{ steps.gate.outputs.milestone }}
+          - head: develop (${{ steps.bump.outputs.sha }})
+
+          Review the gates, merge to main to deploy (release-pipeline), then tag main with \`v${{ steps.validate.outputs.version }}\` to publish the GitHub Release."
+          if gh pr view --base main --head develop --json number --jq .number >/dev/null 2>&1; then
+            gh pr edit develop --title "Release v${{ steps.validate.outputs.version }}" --body "${PR_BODY}"
+            PR_URL="$(gh pr view --base main --head develop --json url --jq .url)"
+          else
+            PR_URL="$(gh pr create --base main --head develop \
+              --title "Release v${{ steps.validate.outputs.version }}" \
+              --body "${PR_BODY}")"
+          fi
+          echo "url=${PR_URL}" >> "$GITHUB_OUTPUT"
+          echo "Release PR: ${PR_URL}"
+
       - name: Write cut summary
         shell: bash
         env:
@@ -137,7 +166,8 @@ jobs:
           - tag: ${{ steps.validate.outputs.tag }}
           - milestone: ${MILESTONE:-n/a}
           - commit: ${{ steps.bump.outputs.sha }}
-          - mode: self-contained run (no event chaining)
+          - pr: ${{ steps.open-pr.outputs.url }}
+          - mode: release PR to main (merge deploys; tag main to publish)
           EOF
 
       - name: Upload cut summary
@@ -149,8 +179,7 @@ jobs:
 
   release:
     name: Build & publish release
-    needs: cut-and-tag
-    if: github.event_name == 'push' || needs.cut-and-tag.result == 'success'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -158,11 +187,11 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ needs.cut-and-tag.outputs.sha || github.sha }}
+          ref: ${{ github.sha }}
 
       - name: Milestone gate (require closed milestone)
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         uses: actions/github-script@v9
         with:
           script: |
@@ -216,7 +245,7 @@ jobs:
       - name: Assemble release info
         shell: bash
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p dist .github/pdm/releases
           {
@@ -231,7 +260,7 @@ jobs:
       - name: Generate release notes
         shell: bash
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p .github/pdm/releases
           notes_file=".github/pdm/releases/release-notes-${TAG_NAME}.md"
@@ -268,8 +297,8 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
-          COMMIT_SHA: ${{ needs.cut-and-tag.outputs.sha || github.sha }}
+          TAG_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
         uses: actions/github-script@v9
         with:
           script: |
@@ -291,5 +320,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-notes
-          path: .github/pdm/releases/release-notes-${{ needs.cut-and-tag.outputs.tag || github.ref_name }}.md
+          path: .github/pdm/releases/release-notes-${{ github.ref_name }}.md
           retention-days: 7

--- a/.github/pdm/workflows/risk-health-check.yml
+++ b/.github/pdm/workflows/risk-health-check.yml
@@ -6,6 +6,7 @@ name: PDM Risk & Code Health Check
 on:
   pull_request:
     branches:
+      - develop
       - main
     types:
       - opened

--- a/.github/workflows/compliance-guardrail.yml
+++ b/.github/workflows/compliance-guardrail.yml
@@ -5,7 +5,7 @@ name: PDM Compliance & Security Guardrail
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ develop, main ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -5,7 +5,7 @@ name: PDM Quality Gate (Status Check)
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ develop, main ]
     types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
 

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,17 +1,20 @@
 name: PDM Release on Tag
 
 # Docs: architecture map, ADRs, and runbook live on the wiki (see the Architecture page).
-# Releases are gated on a closed GitHub milestone titled v<version> and are
-# self-contained: GITHUB_TOKEN-created tags/commits never spawn a new workflow
-# run, so the dispatch path does the whole release (bump + build + createRelease)
-# in one run instead of chaining on a tag push.
+# A version release is a PR to main. The dispatch path is the release cut: it
+# validates the version, enforces the closed-milestone gate (auto-creating the
+# milestone as open if missing), bumps frontend/package.json on develop, and
+# opens (or updates) the release PR develop -> main titled Release v<version>.
+# Merging that PR pushes main, which triggers release-pipeline for real; tagging
+# main with v<version> publishes the GitHub Release via the push-tag path below.
+# GITHUB_TOKEN-created tags/commits never spawn a new workflow run, so the cut
+# (dispatch -> PR) and the publish (tag push) stay explicit, human steps.
 #
 # Paths:
-#   - workflow_dispatch (version input): validates, gates on the milestone
-#     (auto-creates it as open if missing), bumps frontend/package.json on
-#     develop, then builds and creates the GitHub Release in the same run.
-#   - push of a v* tag: still gated on a closed milestone before publishing
-#     (manual tag pushes cannot bypass the gate).
+#   - workflow_dispatch (version input): validates, gates on the milestone,
+#     bumps frontend/package.json on develop, and opens the release PR to main.
+#   - push of a v* tag: builds and creates the GitHub Release, still gated on a
+#     closed milestone (manual tag pushes cannot bypass the gate).
 
 on:
   push:
@@ -31,16 +34,18 @@ concurrency:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
-  cut-and-tag:
-    name: Cut release (bump develop + tag)
+  cut-release-pr:
+    name: Cut release PR (bump develop + open PR to main)
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.validate.outputs.version }}
       tag: ${{ steps.validate.outputs.tag }}
       sha: ${{ steps.bump.outputs.sha }}
+      pr_url: ${{ steps.open-pr.outputs.url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -125,6 +130,30 @@ jobs:
           fi
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Open release PR to main
+        id: open-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          PR_BODY="Release cut by the PDM delivery engine (milestone-gated).
+
+          - version: v${{ steps.validate.outputs.version }}
+          - milestone: ${{ steps.gate.outputs.milestone }}
+          - head: develop (${{ steps.bump.outputs.sha }})
+
+          Review the gates, merge to main to deploy (release-pipeline), then tag main with \`v${{ steps.validate.outputs.version }}\` to publish the GitHub Release."
+          if gh pr view --base main --head develop --json number --jq .number >/dev/null 2>&1; then
+            gh pr edit develop --title "Release v${{ steps.validate.outputs.version }}" --body "${PR_BODY}"
+            PR_URL="$(gh pr view --base main --head develop --json url --jq .url)"
+          else
+            PR_URL="$(gh pr create --base main --head develop \
+              --title "Release v${{ steps.validate.outputs.version }}" \
+              --body "${PR_BODY}")"
+          fi
+          echo "url=${PR_URL}" >> "$GITHUB_OUTPUT"
+          echo "Release PR: ${PR_URL}"
+
       - name: Write cut summary
         shell: bash
         env:
@@ -137,7 +166,8 @@ jobs:
           - tag: ${{ steps.validate.outputs.tag }}
           - milestone: ${MILESTONE:-n/a}
           - commit: ${{ steps.bump.outputs.sha }}
-          - mode: self-contained run (no event chaining)
+          - pr: ${{ steps.open-pr.outputs.url }}
+          - mode: release PR to main (merge deploys; tag main to publish)
           EOF
 
       - name: Upload cut summary
@@ -149,8 +179,7 @@ jobs:
 
   release:
     name: Build & publish release
-    needs: cut-and-tag
-    if: github.event_name == 'push' || needs.cut-and-tag.result == 'success'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -158,11 +187,11 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ needs.cut-and-tag.outputs.sha || github.sha }}
+          ref: ${{ github.sha }}
 
       - name: Milestone gate (require closed milestone)
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         uses: actions/github-script@v9
         with:
           script: |
@@ -216,7 +245,7 @@ jobs:
       - name: Assemble release info
         shell: bash
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p dist .github/pdm/releases
           {
@@ -231,7 +260,7 @@ jobs:
       - name: Generate release notes
         shell: bash
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
           mkdir -p .github/pdm/releases
           notes_file=".github/pdm/releases/release-notes-${TAG_NAME}.md"
@@ -268,8 +297,8 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          TAG_NAME: ${{ needs.cut-and-tag.outputs.tag || github.ref_name }}
-          COMMIT_SHA: ${{ needs.cut-and-tag.outputs.sha || github.sha }}
+          TAG_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
         uses: actions/github-script@v9
         with:
           script: |
@@ -291,5 +320,5 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-notes
-          path: .github/pdm/releases/release-notes-${{ needs.cut-and-tag.outputs.tag || github.ref_name }}.md
+          path: .github/pdm/releases/release-notes-${{ github.ref_name }}.md
           retention-days: 7

--- a/.github/workflows/risk-health-check.yml
+++ b/.github/workflows/risk-health-check.yml
@@ -6,6 +6,7 @@ name: PDM Risk & Code Health Check
 on:
   pull_request:
     branches:
+      - develop
       - main
     types:
       - opened

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@ Canonical workflows live in `.github/pdm/workflows/`; `.github/workflows/` holds
 ```sh
 make lint          # actionlint on canonical + execution copies, then drift check
 make test-frontend # native frontend suite: install + lint + typecheck + test + build
-make test-gh       # push current branch + open/update a PR to main, then gh pr checks --watch
+make test-gh       # push current branch + open/update a PR to develop, then gh pr checks --watch
 ```
 
-Open a PR to `main` and GitHub runs the three PR workflows natively; the release pipeline is exercised via `workflow_dispatch` (default `dry_run: true`). On PR runs the workflows post comments; on non-PR (`workflow_dispatch`) runs they upload report/deployment records as run artifacts instead.
+Open a PR to `develop` and GitHub runs the three PR workflows natively (they also gate release PRs to `main`); the release pipeline is exercised via `workflow_dispatch` (default `dry_run: true`). On PR runs the workflows post comments; on non-PR (`workflow_dispatch`) runs they upload report/deployment records as run artifacts instead. `main` only receives version-release PRs (cut by the `release-on-tag` dispatch).
 
 ## Gotchas (hard-earned)
 
@@ -25,7 +25,7 @@ Open a PR to `main` and GitHub runs the three PR workflows natively; the release
 - **github-script v7** already injects `context` and `github`; never redeclare `const { context } = …`. Comment-posting steps are guarded with `context.payload.pull_request?.number` so non-PR runs don't hit the API.
 - **Cross-job files don't persist on GitHub** (each job gets a fresh workspace). Each workflow that writes reports/records must upload them as run artifacts from the same job that wrote them; artifacts use `if: !github.event.pull_request` (or `real_deploy == 'false'`) guards.
 - **Workflows run on every PR synchronize** and each posts a comment — expect a comment per push on active PRs.
-- **`GITHUB_TOKEN`-triggered events never chain workflow runs.** Commits/tags pushed by `GITHUB_TOKEN` don't re-trigger `push` (or `push: tags`) workflows — only `workflow_dispatch`/`repository_dispatch` can be triggered that way. `release-on-tag` is therefore self-contained: its dispatch path does the whole release (milestone gate → `develop` bump → `createRelease`) instead of pushing a tag and relying on a second run.
+- **`GITHUB_TOKEN`-triggered events never chain workflow runs.** Commits/tags pushed by `GITHUB_TOKEN` don't re-trigger `push` (or `push: tags`) workflows — only `workflow_dispatch`/`repository_dispatch` can be triggered that way. `release-on-tag` is therefore two explicit steps instead of chaining: its dispatch path cuts the release (milestone gate → `develop` bump → open the release PR `develop → main`), and publishing (tag `main` with `v<version>` → `createRelease`) only happens after a human merges that PR and pushes the tag.
 - **`gh` CLI in a workflow requires `GH_TOKEN` explicitly.** The runner's `gh` refuses to use `GITHUB_TOKEN` automatically ("set the GH_TOKEN environment variable"). Any step calling `gh` must pass `env: GH_TOKEN: ${{ github.token }}` — the repo's other workflows use `github-script` (token injected), so this only bites new direct-`gh` steps.
 - **`main` merge blocks can be silent `repo-settings` misconfiguration.** With no `CODEOWNERS`, `require_code_owner_reviews` makes the only "owner" the PR author (unapprovable), and `lock_branch` makes `main` fully read-only — either permanently blocks every PR merge even with green gates. Diagnose with `gh api .../branches/main/protection`; fix by `PUT`ting the full `.../protection` body (`lock_branch: false`, `require_code_owner_reviews: false`, `required_status_checks.contexts: ["PDM Quality Gate (Status Check)"]`).
 - **`make sync` must be run before committing**: GitHub only executes workflows from `.github/workflows/`, and `make lint` fails on drift between the two trees.

--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,15 @@ lint:
 	fi
 
 # Verify the PDM workflows natively on GitHub: push the current branch and open
-# (or update) a PR to main so the pull_request triggers execute, then surface
-# the run status. Requires the gh CLI (gh auth login).
+# (or update) a PR to develop so the pull_request triggers execute, then surface
+# the run status. Requires the gh CLI (gh auth login). main only receives PRs
+# for version releases (cut by release-on-tag dispatch).
 test-gh:
 	@BRANCH=$$(git symbolic-ref --short HEAD); \
-	echo "Pushing $$BRANCH and opening a PR to main (PDM workflows will run natively)..."; \
+	echo "Pushing $$BRANCH and opening a PR to develop (PDM workflows will run natively)..."; \
 	git push -u origin $$BRANCH; \
 	if ! gh pr view $$BRANCH --json number --jq .number >/dev/null 2>&1; then \
-		gh pr create --base main --head $$BRANCH \
+		gh pr create --base develop --head $$BRANCH \
 			--title "PDM workflow run ($$BRANCH)" \
 			--body "Opened by \`make test-gh\` to run the PDM quality gates natively on GitHub."; \
 	fi; \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The delivery engine is **live and operating at cadence** — Phases 0–21 compl
 - **Releases**: `v0.1.0`, `v0.2.0`, `v0.3.0` shipped via the milestone-gated `release-on-tag` pipeline. Train 2 (departs 08-31, cutoff 08-28) is pending — `v0.3.0` published early, inside train 1's window, so the on-time signal honestly stays 1/1 until a release publishes inside train 2's window `[08-31, 09-14)` (ADR 0009).
 - **Latest truthing readout** (P16-T4, 90d window, run 32115287697): deployment frequency dev 1.79/wk · staging/prod 1.56/wk · pages 2.88/wk; lead time median **6m** (11 PRs); change-failure rate **1.0%** (1/100 — the P10-T2 drill event only); MTTR proxy median **7h 15m** (1 event). The P21 close-out telemetry run (32205889156) confirmed the same numbers unchanged. Full readouts and history: see the [wiki ROADMAP](https://github.com/frdrpo/learning-pdm-fintech-delivery-engine/wiki/ROADMAP).
 - **Release train**: 14-day cadence (ADR 0009); train 3 departs **09-14** (cutoff 09-11), train 4 departs 09-28 — see the [Release Train Calendar](https://github.com/frdrpo/learning-pdm-fintech-delivery-engine/wiki/Release-Train-Calendar).
-- **Branch topology**: `develop` (default, integration) + `main` (protected; requires the `PDM Quality Gate (Status Check)`). Feature/track branches land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `main`.
+- **Branch topology**: `develop` (default, integration) + `main` (protected; requires the `PDM Quality Gate (Status Check)`). Feature/track branches fork from `develop` and land via PRs to `develop`; workflow verification runs through `make test-gh` PRs to `develop`. `main` only receives version-release PRs (opened by the `release-on-tag` dispatch), which run the real deployment pipeline when merged.
 - **Product surface**: the frontend now renders the live delivery telemetry at [`/delivery`](https://frdrpo.github.io/learning-pdm-fintech-delivery-engine/delivery/) — DORA metric cards, the release-train status panel (ADR 0009 window logic), and the audit trail — from a committed, versioned snapshot of the `delivery-telemetry` export (honest `insufficient-data` empty states, never invented numbers).
 
 ## Repository Structure
@@ -30,7 +30,7 @@ All PDM workflow and deployment material is consolidated under a single folder, 
   - `release-pipeline.yml` - Promotes builds through development/staging/production environments and records dry-run deployments.
   - `delivery-telemetry.yml` - Exports the GitHub-native delivery audit trail and DORA-style telemetry as run artifacts (weekly + on demand).
   - `security-rescan.yml` - Weekly + on-demand gitleaks/OSV re-scan; uploads a report artifact and files an issue on blocking schedule findings.
-  - `release-on-tag.yml` - Milestone-gated releases: `workflow_dispatch` with a `version` (or a `v*` tag push) cuts the release off `develop` — requires a closed `v<version>` milestone, bumps `frontend/package.json`, and creates the GitHub Release in one self-contained run.
+  - `release-on-tag.yml` - Milestone-gated releases: `workflow_dispatch` with a `version` cuts the release — requires a closed `v<version>` milestone, bumps `frontend/package.json` on `develop`, and opens the release PR `develop → main`. Merging it runs the real `release-pipeline`; a `v*` tag push on `main` publishes the GitHub Release (still milestone-gated).
   - `publish-pages.yml` - Publishes the static-exported frontend to GitHub Pages on every push to `develop` (the live `DEPLOY_VERIFY_URL` target).
   - `release-train-simulator.yml` - Runs the deterministic release-train model headlessly (`workflow_dispatch` only); labeled artifacts, never native records (ADR 0010).
   - `copykit-smoke.yml` - P17 copy-kit rehearsal: replays the engine copy-kit (§1→§8) in a throwaway consumer workspace on a fresh runner (`workflow_dispatch` only; local equivalent `make test-consumer-path`).
@@ -52,9 +52,9 @@ flowchart LR
         C --> D["Push branch"]
     end
 
-    D --> P["Open PR to main"]
+    D --> P["Open PR to develop"]
 
-    subgraph Gates["PR gates (every PR to main)"]
+    subgraph Gates["PR gates (every PR to develop + main)"]
         RH["risk-health-check — gitleaks + OSV + code health + AI risk review"]
         CG["compliance-guardrail — trufflehog base..head"]
         QG["quality-gate (REQUIRED) — actionlint + lint/typecheck/test/build"]
@@ -68,16 +68,23 @@ flowchart LR
     CG --> CG1["PR comment (pass/fail)"]
     QG --> QG1["PR comment / gate-report artifact"]
 
-    RH --> M["Merge to main (only when all gates pass)"]
-    CG --> M
-    QG --> M
+    RH --> DEV["Merge to develop"]
+    CG --> DEV
+    QG --> DEV
 
+    subgraph Release["Version release (on demand)"]
+        CUT["release-on-tag dispatch (version, milestone-gated)"] --> RPR["PR develop → main"]
+        RPR --> QG
+        RPR --> M["Merge to main"]
+        M --> RT["Tag v<version> on main → GitHub Release"]
+    end
+
+    DEV -.->|on demand| CUT
     M --> RP["release-pipeline — build → development → staging → production"]
     RP -->|dry_run: true| RP1["Deploy-record artifacts (dry-run)"]
     RP -->|dry_run: false / push| RP2["GitHub Deployment API (real deployments)"]
 
-    M -.->|push to develop| PP["publish-pages → GitHub Pages (live verify target)"]
-    M -.->|dispatch v* · milestone-gated| RT["release-on-tag → GitHub Release"]
+    DEV -.->|push to develop| PP["publish-pages → GitHub Pages (live verify target)"]
 
     subgraph Scheduled["Scheduled + on demand"]
         SR["security-rescan — weekly Mon 02:00 UTC"]
@@ -94,11 +101,11 @@ flowchart LR
 
 Notes on the flow:
 
-- `quality-gate` is the single required branch-protection check on `main` — a PR merges only when all three PR workflows pass.
+- `quality-gate` is the single required branch-protection check on `main` — a release PR merges only when all three PR workflows pass. The same three PR workflows run on every PR to `develop`.
 - On PR runs, workflows post comments to the PR; on non-PR (`workflow_dispatch`) runs they upload reports and dry-run deployment records as run artifacts instead.
 - The canonical source of truth is `.github/pdm/workflows/`; `.github/workflows/` holds byte-identical execution copies kept in sync via `make sync`.
 - A `push` to `main` always runs the release pipeline for real (`dry_run: false`); `workflow_dispatch` defaults to `dry_run: true`. Staging and production require manual approval.
-- Releases are cut from `develop` via `release-on-tag` `workflow_dispatch` (version input): gated on a closed milestone `v<version>`, bumps `frontend/package.json` on `develop`, and creates the GitHub Release in the same run (`GITHUB_TOKEN`-triggered events never spawn a new run, so no tag-push chaining). Manual `v*` tag pushes still publish but pass the same milestone gate.
+- Version releases are PRs to `main`, cut by `release-on-tag` `workflow_dispatch` (version input): gated on a closed milestone `v<version>`, it bumps `frontend/package.json` on `develop` and opens the release PR `develop → main`. Merging the PR pushes `main` (running `release-pipeline` for real); tagging `main` with `v<version>` publishes the GitHub Release (tag pushes still pass the same milestone gate).
 
 ## Prerequisites
 
@@ -118,7 +125,7 @@ The `Makefile` is the local operator surface for the engine. All targets run nat
 | `make sync-deps` | Adopt dependabot version bumps from `.github/workflows/` back into canonical (then `make sync`) |
 | `make fleet-sync` | Install the canonical agent fleet (`agents/`) into the local runtime (`.opencode/agent/`, ADR 0015) |
 | `make test-frontend` | CI-parity frontend suite: install + lint + typecheck + test + build (pnpm) |
-| `make test-gh` | Push current branch + open/update a PR to `main`, then `gh pr checks --watch` the native gate runs |
+| `make test-gh` | Push current branch + open/update a PR to `develop`, then `gh pr checks --watch` the native gate runs |
 | `make test-consumer-path` | P17 copy-kit rehearsal: execute kit §1→§8 in a throwaway consumer workspace (`scripts/consumer-smoke.mjs`) |
 | `make topology-check` | Verify the documented repo topology against the live repo (`scripts/wire-topology.mjs --check`) |
 | `make topology-apply` | Converge the topology (branch protection, environments, Pages, `DEPLOY_VERIFY_URL`) |
@@ -132,13 +139,13 @@ Workflows are verified by running them on GitHub — no local Docker/`act` harne
    make sync   # copy canonical workflows to .github/workflows/
    make lint   # actionlint + drift check against the copies
    ```
-2. Open a PR to `main` (or `make test-gh` to push + open/update the PR for the current branch). GitHub runs the PDM workflows natively:
-   - `quality-gate` (actionlint + lint/typecheck/test/build) — required check
+2. Open a PR to `develop` (or `make test-gh` to push + open/update the PR for the current branch). GitHub runs the PDM workflows natively:
+   - `quality-gate` (actionlint + lint/typecheck/test/build) — the required check on `main` (release PRs); runs as a gate check on `develop` PRs
    - `risk-health-check` (gitleaks + OSV + code health) — posts a PR comment
    - `compliance-guardrail` (trufflehog) — posts a PR comment
 3. For non-PR runs (`workflow_dispatch`), reports and dry-run deployment records are uploaded as run artifacts instead of PR comments — download them from the run's "Artifacts" section.
 
-`push` to `main` also triggers `release-pipeline` (real `createDeployment`); `workflow_dispatch` defaults to `dry_run: true` so manual runs skip the Deployment API.
+`push` to `main` (a merge of a release PR cut by `release-on-tag` dispatch, or any other merge) triggers `release-pipeline` (real `createDeployment`); `workflow_dispatch` defaults to `dry_run: true` so manual runs skip the Deployment API.
 
 ## Frontend Testing
 


### PR DESCRIPTION
…a release PR

- PR gates (quality-gate, risk-health-check, compliance-guardrail) now trigger on PRs to develop and main
- make test-gh opens/updates a PR to develop instead of main
- release-on-tag dispatch cuts the release: milestone gate, develop version bump, then opens the release PR develop -> main; merging deploys via release-pipeline, tagging main publishes the GitHub Release
- docs: README flow, AGENTS.md gotcha