### PR TITLE
fix(frontend): harden delivery-health formatters for negative and non-finite input

### DIFF
--- a/frontend/src/lib/delivery-health/format.test.ts
+++ b/frontend/src/lib/delivery-health/format.test.ts
@@ -22,6 +22,17 @@ describe("formatHours", () => {
   it("renders zero as 0m", () => {
     expect(formatHours(0)).toBe("0m");
   });
+
+  it("clamps negative values to 0m", () => {
+    expect(formatHours(-1)).toBe("0m");
+    expect(formatHours(-0.5)).toBe("0m");
+  });
+
+  it("clamps non-finite values to 0m", () => {
+    expect(formatHours(NaN)).toBe("0m");
+    expect(formatHours(Infinity)).toBe("0m");
+    expect(formatHours(-Infinity)).toBe("0m");
+  });
 });
 
 describe("formatPercent", () => {
@@ -35,6 +46,12 @@ describe("formatPercent", () => {
 
   it("renders zero percent", () => {
     expect(formatPercent(0)).toBe("0.0%");
+  });
+
+  it("renders non-finite input as an em dash", () => {
+    expect(formatPercent(NaN)).toBe("—");
+    expect(formatPercent(Infinity)).toBe("—");
+    expect(formatPercent(-Infinity)).toBe("—");
   });
 });
 

--- a/frontend/src/lib/delivery-health/format.ts
+++ b/frontend/src/lib/delivery-health/format.ts
@@ -3,6 +3,7 @@
 // surface and the run-artifact reports agree on how values are presented.
 
 export function formatHours(hours: number): string {
+  if (!Number.isFinite(hours) || hours < 0) return "0m";
   const days = Math.floor(hours / 24);
   const remainingHours = Math.floor(hours % 24);
   const minutes = Math.round((hours - days * 24 - remainingHours) * 60);
@@ -12,6 +13,7 @@ export function formatHours(hours: number): string {
 }
 
 export function formatPercent(ratio: number): string {
+  if (!Number.isFinite(ratio)) return "—";
   return `${(ratio * 100).toFixed(1)}%`;
 }
 


### PR DESCRIPTION
## What
Hardens `frontend/src/lib/delivery-health/format.ts` for edge-case inputs, closing #190.

- `formatHours`: clamps negative and non-finite (`NaN`, `±Infinity`) values to `"0m"` — previously `formatHours(-1)` returned `"1440m"` and `NaN` produced garbage.
- `formatPercent`: returns `"—"` for non-finite input (matching `formatDate` em-dash convention) — previously `"NaN%"`.

## Why
Executed as the delivery rehearsal for issue #190 (Copilot cloud agent route is blocked on this account — 403 entitlement). Change is limited to the two files in the issue scope guard.

## Evidence
- TDD: new failing tests first (3 failures), then fix → 126/126 tests pass
- `pnpm lint` ✓ · `pnpm typecheck` ✓ · `pnpm test` ✓ · `pnpm build` ✓
- Commit: `29ca83bc`

## Gate
PR workflows run natively on this PR (PDM Quality Gate + friends).