### PR TITLE
feat(examples): reference implementations & workflow templates (#184)

### DIFF
--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -34,6 +34,12 @@ jobs:
         shell: bash
         run: ./actionlint -color -pyflakes=0
 
+      - name: Validate examples and templates (Issue #184)
+        shell: bash
+        run: |
+          export PATH="$GITHUB_WORKSPACE:$PATH"
+          node scripts/examples-test.mjs
+
   code-quality:
     name: Code Quality (lint/typecheck/test/build)
     runs-on: ubuntu-latest

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -34,6 +34,12 @@ jobs:
         shell: bash
         run: ./actionlint -color -pyflakes=0
 
+      - name: Validate examples and templates (Issue #184)
+        shell: bash
+        run: |
+          export PATH="$GITHUB_WORKSPACE:$PATH"
+          node scripts/examples-test.mjs
+
   code-quality:
     name: Code Quality (lint/typecheck/test/build)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PDM_WF    := .github/pdm/workflows
 GH_WF     := .github/workflows
 
-.PHONY: lint sync sync-deps fleet-sync test-frontend test-gh test-consumer-path topology-check topology-apply
+.PHONY: lint sync sync-deps fleet-sync test-frontend test-gh test-consumer-path test-examples topology-check topology-apply
 
 # Mirror canonical workflows into .github/workflows (GitHub only executes there)
 sync:
@@ -71,6 +71,12 @@ test-gh:
 # Requires actionlint + pnpm on PATH (homebrew pnpm on macOS; see AGENTS.md).
 test-consumer-path:
 	@node scripts/consumer-smoke.mjs --root . $(REHEARSAL_ARGS)
+
+# Issue #184 — validate the examples/ deliverables offline (READMEs + structure,
+# agent scrub-rules, workflow template actionlint + artifact-guard invariants,
+# mocked "agent runner" contract test). Runs in the quality-gate workflow-lint job.
+test-examples:
+	@node scripts/examples-test.mjs
 
 # Kit §2: idempotent topology check/apply against the live repo (gh CLI).
 # `make topology-check` verifies the documented target state; `make topology-apply`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ All PDM workflow and deployment material is consolidated under a single folder, 
 - `.github/pdm/reports/` - Risk and quality-gate reports uploaded as run artifacts (not committed).
 - `.github/workflows/` - Mirrored execution copies of `.github/pdm/workflows/`. GitHub only executes workflows from this directory, so keep the copies in sync with `make sync`.
 - `agents/` - The canonical AI agent fleet (ADR 0015): five scrubbed, model-pin-free agent definitions (`pm`, `docs`, `software-engineer`, `junior-software-engineer`, `docs-reader`) installed into a local opencode runtime with `make fleet-sync`. Runtime config (providers/models, keys) stays local — `.opencode/` and `opencode.json` are gitignored; `agents/opencode.example.json` is the scrubbed template (`{env:...}` overridable).
+- `examples/` - Reference implementations and workflow templates for adopting the PDM framework and AI agent patterns (Issue #184): `fintech-agent-runner/` (scrubbed agent fleet + `fleet-sync`), `pdm-workflow-templates/` (actionlint-valid quality-gate/compliance/agent-runner templates), and `agent-skills-demo/` (skill-resolution demo + mocked `node:test` CI scaffold). Validated offline by `make test-examples`, wired into the quality gate.
 - `frontend/` - Next.js 16 website (App Router, TypeScript, Tailwind v4) — a dark fintech landing page with Vitest unit + component tests, plus a `/delivery` route rendering the live delivery-health snapshot (DORA metrics, release-train status, audit trail). This is the application the delivery gates exercise.
 
 ## System Flow
@@ -127,6 +128,7 @@ The `Makefile` is the local operator surface for the engine. All targets run nat
 | `make test-frontend` | CI-parity frontend suite: install + lint + typecheck + test + build (pnpm) |
 | `make test-gh` | Push current branch + open/update a PR to `develop`, then `gh pr checks --watch` the native gate runs |
 | `make test-consumer-path` | P17 copy-kit rehearsal: execute kit §1→§8 in a throwaway consumer workspace (`scripts/consumer-smoke.mjs`) |
+| `make test-examples` | Issue #184 examples validation: READMEs + structure, agent scrub-rules, workflow-template actionlint + artifact guards, mocked contract test (`scripts/examples-test.mjs`) |
 | `make topology-check` | Verify the documented repo topology against the live repo (`scripts/wire-topology.mjs --check`) |
 | `make topology-apply` | Converge the topology (branch protection, environments, Pages, `DEPLOY_VERIFY_URL`) |
 
@@ -146,6 +148,22 @@ Workflows are verified by running them on GitHub — no local Docker/`act` harne
 3. For non-PR runs (`workflow_dispatch`), reports and dry-run deployment records are uploaded as run artifacts instead of PR comments — download them from the run's "Artifacts" section.
 
 `push` to `main` (a merge of a release PR cut by `release-on-tag` dispatch, or any other merge) triggers `release-pipeline` (real `createDeployment`); `workflow_dispatch` defaults to `dry_run: true` so manual runs skip the Deployment API.
+
+## Examples & Templates (Issue #184)
+
+The `examples/` tree ships reference implementations and workflow templates for adopting the PDM framework and AI agent patterns:
+
+- `examples/fintech-agent-runner/` — a minimal opencode agent fleet (`pm`, `delivery-engineer`, `compliance-reviewer`) with scrub-safe definitions, `fleet-sync`, and a local `node --test` hygiene test (ADR 0015 pattern).
+- `examples/pdm-workflow-templates/` — ready-to-copy actionlint-valid workflows: `quality-gate.yml`, `compliance-guardrail.yml`, `agent-runner.yml` (dispatch-only).
+- `examples/agent-skills-demo/` — skill-resolution demo + a dependency-free mocked `node:test` CI scaffold.
+
+Validate them offline, or let the quality gate do it on every PR:
+
+```bash
+make test-examples   # README/structure + fleet scrub rules + template actionlint/guards + mock contract test
+```
+
+To adopt: copy a subproject into your repo, follow its `README.md` (cp commands + renames), then run `make test-examples` and (for templates) `make sync`/`make lint`. See the [wiki Examples and Templates page](https://github.com/frdrpo/learning-pdm-fintech-delivery-engine/wiki/Examples-and-Templates).
 
 ## Frontend Testing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,30 @@
+# Examples & Templates
+
+Reference implementations and workflow templates for adopting the PDM framework and AI agent patterns in a fintech project. Each example is a self-contained, minimal subproject you can copy into your own repo; `make test-examples` validates them offline (structure, agent scrub-rules, actionlint on the workflow templates, and a mocked CI test scaffold).
+
+"PDM" here means **Product Delivery Management**, not the Python package manager.
+
+## The examples
+
+| Example | What it demonstrates | Adopt when |
+|---|---|---|
+| [`fintech-agent-runner/`](fintech-agent-runner/) | A minimal opencode agent fleet (`pm` + `delivery-engineer` + `compliance-reviewer`) with scrub-safe definitions, a `fleet-sync` Makefile target, and a runtime-config template (`opencode.example.json`). Mirrors ADR 0015. | You want the delivery-gate agents running locally the way this repo's fleet does. |
+| [`pdm-workflow-templates/`](pdm-workflow-templates/) | Ready-to-copy GitHub Actions workflow templates: a quality gate, a compliance guardrail, and a `workflow_dispatch` agent-runner job. Validated with actionlint by the integration test. | You want the PR gates in a fresh repo without rewriting the workflows from scratch. |
+| [`agent-skills-demo/`](agent-skills-demo/) | A skill-consumption demo + a dependency-free `node:test` scaffold showing how to add "mocked integration tests that run example workflows in CI." | You want the agent skills pattern plus a no-install test scaffold for validating workflow contracts. |
+
+## Adoption path (5 minutes)
+
+1. Pick the subproject that matches your gap (agent fleet, workflow templates, or skills + test scaffold).
+2. Copy the subproject into your repo (see each subproject's `README.md` for the exact `cp` commands and what to rename).
+3. For workflow templates: drop them under `.github/pdm/workflows/`, then `make sync` if you adopt the canonical→execution convention, or straight into `.github/workflows/`.
+4. Run the example's own tests and this repo's example integration test:
+   ```sh
+   make test-examples   # struct + scrub rules + actionlint on templates + mock test scaffold
+   ```
+5. Pack in the gate: wire `scripts/examples-test.mjs` into your CI (the reference does it in `quality-gate.yml`'s `workflow-lint` job).
+
+## Links
+
+- Wiki: [[Examples-and-Templates]] — usage guide and the rationale behind each example.
+- Reference architecture: [[Architecture]], copy-checklist: [[Engine-Copy-Kit]].
+- Agent-fleet canon: [`agents/`](../agents/) (ADR 0015).

--- a/examples/agent-skills-demo/README.md
+++ b/examples/agent-skills-demo/README.md
@@ -1,0 +1,39 @@
+# Agent Skills Demo + Mock CI Test Scaffold
+
+Two ideas in one minimal subproject:
+
+1. **A skill-consumption demo** — how an agent ("runner") loads a skill definition before acting, the same pattern opencode uses (`skill` tool ← description match). Includes a scrubbed `opencode.example.json`.
+2. **A dependency-free "mocked integration test" scaffold** — a `node:test` harness that simulates running a workflow contract offline (no GitHub). This is the pattern the repo's CI integration test uses: workflow expectations are tested with mocked payloads instead of a real runner.
+
+## What's here
+
+```
+skills/
+  compliance-review.md   — skill definition read by the agent before a review
+  delivery-brief.md      — skill definition for producing a delivery brief
+runner.mjs               — tiny "agent runner" that resolves a skill by description
+test/skills.test.mjs     — node:test scaffold (no deps, mocked inputs)
+opencode.example.json    — scrubbed runtime config template (copy to opencode.json)
+README.md                — this file
+```
+
+## Run the scaffold (no install)
+
+```sh
+node --test 'test/*.test.mjs'     # < 1s, zero dependencies
+node runner.mjs "compliance review"   # resolves the compliance-review skill
+```
+
+## The "mocked in CI" idea
+
+The test feeds `runner.mjs` human-readable skill names and asserts it resolves the right definition, exactly like the repo's `scripts/examples-test.mjs` *mocks* the workflow triggers it validates (it parses `on:` and artifact guards rather than launching GitHub Actions). Teams adopt this scaffold to validate their agent/action contracts offline before the native PR run.
+
+## Adopt in your repo
+
+```sh
+cp -R skills runner.mjs test your-repo/
+cp opencode.example.json your-repo/opencode.json
+node --test your-repo/test/
+```
+
+Keep `opencode.json` out of git (per-machine model pins — the fleet canon lives in `agents/`).

--- a/examples/agent-skills-demo/opencode.example.json
+++ b/examples/agent-skills-demo/opencode.example.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "{env:OPENCODE_MODEL}",
+  "small_model": "{env:OPENCODE_SMALL_MODEL}",
+  "permission": {
+    "bash": {
+      "git *": "allow",
+      "git": "allow"
+    }
+  }
+}

--- a/examples/agent-skills-demo/runner.mjs
+++ b/examples/agent-skills-demo/runner.mjs
@@ -1,0 +1,54 @@
+// Minimal "agent runner": resolves a skill definition by matching the request
+// against each skill's `description` frontmatter (the same contract the opencode
+// `skill` tool uses: description match -> load instructions). Kept dependency-free
+// so the mock CI test can exercise it offline.
+
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SKILLS = path.resolve(HERE, "skills");
+
+export function skillNameFrom(fm) {
+  return fm?.name ?? path.basename(SKILLS, ".md");
+}
+
+export function parseFrontmatter(text) {
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  const fm = {};
+  for (const line of m[1].split("\n")) {
+    const kv = line.match(/^([A-Za-z_-]+):\s*(.*)$/);
+    if (kv) fm[kv[1]] = kv[2];
+  }
+  return fm;
+}
+
+export function loadSkills(dir = SKILLS) {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => {
+      const text = readFileSync(path.join(dir, f), "utf8");
+      const fm = parseFrontmatter(text);
+      return { file: f, name: skillNameFrom(fm), description: fm?.description ?? "" };
+    });
+}
+
+export function resolveSkill(request, skills = loadSkills()) {
+  const norm = (s) => s.toLowerCase().replace(/[\s_-]+/g, " ");
+  const q = norm(request);
+  return (
+    skills.find((s) => norm(s.name).includes(q)) ??
+    skills.find((s) => norm(s.description).includes(q)) ?? {
+      name: "none",
+      description: "No skill matched this request.",
+    }
+  );
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const request = process.argv[2] ?? "no request";
+  const skill = resolveSkill(request);
+  console.log(`Resolved skill for "${request}": ${skill.name}`);
+}

--- a/examples/agent-skills-demo/skills/compliance-review.md
+++ b/examples/agent-skills-demo/skills/compliance-review.md
@@ -1,0 +1,14 @@
+---
+name: compliance-review
+description: Compliance review for fintech diffs. Use when asked to review code for regulatory, data-privacy, or secrets risk before merge.
+skills: review
+---
+
+You are performing a compliance review. Follow these steps:
+
+1. Read the diff (or requested files) with the `read` tool.
+2. Check evidence against the repo's documented compliance rules.
+3. Look for: hardcoded secrets/tokens, PII/PCI data handling, floating-point money math, and logging of sensitive data.
+4. Produce a verdict: `pass`, `needs-fix`, or `insufficient-data` — never invent severity.
+
+Output a labeled advisory (`kind: "compliance-advisory"`) — never a native delivery record.

--- a/examples/agent-skills-demo/skills/delivery-brief.md
+++ b/examples/agent-skills-demo/skills/delivery-brief.md
@@ -1,0 +1,12 @@
+---
+name: delivery-brief
+description: Weekly delivery-health brief. Use when asked to summarize delivery telemetry, DORA metrics, or release-train status into a brief.
+skills: brief
+---
+
+You are producing a delivery brief. Follow these steps:
+
+1. Read the latest delivery telemetry snapshot (or compute from the audit trail).
+2. Summarize: deployment frequency, lead time, change-failure rate, time-to-recovery proxy, and release-train status.
+3. Where evidence is missing, report `insufficient-data` — never invent numbers.
+4. Output a labeled advisory (`kind: "agent-advisory"`) — never a native delivery record.

--- a/examples/agent-skills-demo/test/skills.test.mjs
+++ b/examples/agent-skills-demo/test/skills.test.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Agent-skills-demo mock test scaffold (node --test). Zero dependencies:
+// the "CI" here is a local node test that mocks the skill-resolution contract
+// an agent runner uses, instead of launching a real runner.
+
+import assert from "node:assert/strict";
+import { loadSkills, parseFrontmatter, resolveSkill } from "../runner.mjs";
+
+assert.ok(parseFrontmatter, "runner exports parseFrontmatter");
+assert.ok(loadSkills, "runner exports loadSkills");
+assert.ok(resolveSkill, "runner exports resolveSkill");
+
+const skills = loadSkills();
+
+assert.equal(typeof skills.length, "number");
+assert.ok(skills.length >= 2, "expected at least 2 skill definitions");
+
+const compliance = skills.find((s) => s.name === "compliance-review");
+assert.ok(compliance, "compliance-review skill exists");
+assert.match(compliance.description, /compliance/i);
+
+const brief = skills.find((s) => s.name === "delivery-brief");
+assert.ok(brief, "delivery-brief skill exists");
+assert.match(brief.description, /delivery/i);
+
+assert.equal(resolveSkill("compliance review").name, "compliance-review");
+assert.equal(resolveSkill("delivery brief").name, "delivery-brief");
+
+const nomatch = resolveSkill("nothing matches this");
+assert.equal(nomatch.name, "none");
+
+// Every skill carries a name + description frontmatter (the opencode contract).
+for (const s of loadSkills()) {
+  assert.ok(s.name && s.name !== "none", `${s.file} missing name frontmatter`);
+  assert.ok(s.description, `${s.file} missing description frontmatter`);
+}

--- a/examples/fintech-agent-runner/Makefile
+++ b/examples/fintech-agent-runner/Makefile
@@ -1,0 +1,13 @@
+.PHONY: fleet-sync test
+
+# Copy the canonical agent fleet (agents/) into this repo's opencode runtime
+# (.opencode/agent/). One-way copy — the local install is gitignored local state,
+# runtime config (providers/models, keys) stays local (ADR 0015).
+fleet-sync:
+	@mkdir -p .opencode/agent
+	@cp agents/*.md .opencode/agent/
+	@echo "Installed agents/ -> .opencode/agent/ (runtime config stays local)"
+
+# Local scrub-rule + frontmatter test for the fleet definitions.
+test:
+	node --test 'test/*.test.mjs'

--- a/examples/fintech-agent-runner/README.md
+++ b/examples/fintech-agent-runner/README.md
@@ -1,0 +1,52 @@
+# Fintech Agent Runner — reference implementation
+
+A minimal opencode agent fleet for a regulated fintech product. Demonstrates the ADR 0015 pattern this repo ships: canonical, model-pin-free agent definitions in `agents/`, a one-way `fleet-sync` install into the local runtime, and runtime config (providers/models/keys) kept strictly local.
+
+## What's here
+
+```
+agents/
+  pm.md                — product-delivery planner (subagent, advisory only)
+  delivery-engineer.md — TDD implementation agent (primary)
+  compliance-reviewer.md — read-only fintech/compliance reviewer (subagent)
+  opencode.example.json — scrubbed runtime-config template ({env:...} overridable)
+Makefile                — fleet-sync (+) target
+test/agents.test.mjs    — scrub-rule + frontmatter test (node --test)
+README.md               — this file
+```
+
+## Adopt it in your repo
+
+```sh
+# 1. copy the fleet + Makefile into your repo
+cp -R agents Makefile your-repo/
+cd your-repo
+
+# 2. install the fleet into your opencode runtime (one-way, gitignored)
+make fleet-sync         # agents/*.md -> .opencode/agent/
+
+# 3. create your local runtime config from the scrubbed template
+cp agents/opencode.example.json opencode.json
+# set models via env (never edit opencode.json with real keys in-tree)
+export OPENCODE_MODEL=your/provider:model
+export OPENCODE_SMALL_MODEL=your/provider:small
+```
+
+Keep `.opencode/` and `opencode.json` out of git (they hold per-machine model pins and keys). The definitions in `agents/` must stay scrub-clean: no model pins, no absolute paths, no secrets — the test enforces it.
+
+## Roles
+
+| Agent | Mode | Role |
+|---|---|---|
+| `pm` | subagent | ROADMAP-style delivery plans + GitHub task materialization; advisory only, never commits |
+| `delivery-engineer` | primary | TDD/OOP/SOLID implementation after delegating research |
+| `compliance-reviewer` | subagent | read-only review of diffs for fintech/compliance risk before merge |
+
+## Local verification
+
+```sh
+make fleet-sync
+node --test 'test/*.test.mjs'
+```
+
+The test checks: every `agents/*.md` has a YAML `description:` + `mode:` frontmatter, `mode` is one of the four valid opencode modes, and no definition contains a model pin, an absolute path, a secret, or a failure-classifier word in its description. The top-level `make test-examples` runs this test plus the other examples' checks.

--- a/examples/fintech-agent-runner/agents/compliance-reviewer.md
+++ b/examples/fintech-agent-runner/agents/compliance-reviewer.md
@@ -1,0 +1,31 @@
+---
+description: Read-only compliance reviewer for fintech diffs. Reviews pull requests and changes for regulatory, data-privacy, and secrets risk before merge; proposes fixes but never edits.
+mode: subagent
+temperature: 0.2
+permission:
+  edit: deny
+  bash: deny
+  web: allow
+  read: allow
+  task:
+    docs-reader: allow
+---
+
+You are a read-only compliance reviewer for a fintech delivery repo. You review diffs and repository state for regulatory and data-handling risk and report findings; you never edit files or run commands.
+
+## Scope of review
+
+- **PII/PCI/regulatory data handling**: hardcoded secrets, tokens, keys, or addresses; logging of card/account/personal data; unsafe handling of money amounts (floating point, unchecked math).
+- **Policy-as-code / compliance gates**: confirm the repo's compliance checks exist and run in CI (secrets scanning, dependency scanning) and are not fatally mis-wired.
+- **Data-handling rules for agents**: any agent or automation that processes sensitive data follows the documented rules; model selection is a runtime concern and must not be committed.
+
+## Method
+
+1. Read the diff (or requested files) with the `read` tool.
+2. Check evidence against the repo's documented compliance rules (wiki/`AGENTS.md`).
+3. Do not rely on local caches — use live/latest state where it matters.
+4. Produce a verdict: `pass`, `needs-fix`, or `insufficient-data` (never invent severity or findings).
+
+## Report format
+
+Use labeled advisory output (`kind: "compliance-advisory"`) so it can never be mistaken for a native delivery record. List each finding with `file_path:line`, the risk class, and a concrete recommendation. The `pm`/`delivery-engineer` agents decide what to do with the advisory — you never gate a merge by yourself.

--- a/examples/fintech-agent-runner/agents/delivery-engineer.md
+++ b/examples/fintech-agent-runner/agents/delivery-engineer.md
@@ -1,0 +1,42 @@
+---
+description: Primary software engineering agent that builds with strict TDD, OOP, SOLID, and Clean Code discipline in a fintech codebase, and delegates task research to the local junior-software-engineer subagent first.
+mode: primary
+temperature: 0.3
+permission:
+  edit: allow
+  bash:
+    git *: allow
+    git: allow
+  task:
+    junior-software-engineer: allow
+---
+
+You are a senior software engineer shipping production-quality fintech code with uncompromising discipline: TDD, OOP, SOLID, Clean Code. You never cut corners, skip tests, or work from stale state.
+
+## 1. Preflight work session (always)
+
+1. `git fetch origin`, then inspect `git status -sb` and incoming commits (`git log --oneline HEAD..@{u}`). Never build on a stale checkout.
+2. Read `README.md` and `AGENTS.md` from the repo root at the start of every task.
+3. Derive the exact lint/typecheck/test/build commands from the freshly read README/AGENTS (verify rather than assume).
+4. Delegate task research to `junior-software-engineer` (Task tool, `subagent_type: "junior-software-engineer"`): locate relevant modules/workflows, explain the current implementation, flag bugs and test-coverage gaps against TDD/OOP/SOLID/Clean Code, return `file_path:line` references plus a draft proposal. Always dispatch for non-trivial work; skip only trivial one-line changes and note why.
+
+## 2. TDD: RED — GREEN — REFACTOR
+
+1. **RED** — write a failing test first, colocated beside the module (`*.test.ts`). Behavior-focused, grounded in the junior's research.
+2. **GREEN** — minimal implementation to make it pass; no gold-plating.
+3. **REFACTOR** — improve structure only while the suite is green.
+
+Run the full gate before declaring done — never just the new tests.
+
+## 3. Fintech-specific discipline
+
+- Treat money/identity logic as high-risk: explicit validation, deterministic behavior, no floating-point money math, fail-loud on invalid states.
+- Never log PII or secrets; keep audit-ability (who/what/when) without data leakage.
+- Compliance-sensitive fields are handled by the `compliance-reviewer` agent — defer the final review rather than self-approving.
+
+## 4. Definition of done
+
+- Full suite green (not just new tests), lint + typecheck clean, build succeeds.
+- Any `.github/pdm/workflows/` edit: `make sync` then `make lint` — never hand-edit execution copies.
+- Research from the junior subagent consumed and reflected (or a note why skipped).
+- Summary to the user: what changed, test results, any remote-sync differences.

--- a/examples/fintech-agent-runner/agents/opencode.example.json
+++ b/examples/fintech-agent-runner/agents/opencode.example.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "{env:OPENCODE_MODEL}",
+  "small_model": "{env:OPENCODE_SMALL_MODEL}",
+  "disabled_providers": [
+    "github-copilot",
+    "github-copilot-enterprise"
+  ],
+  "permission": {
+    "bash": {
+      "git *": "allow",
+      "git": "allow"
+    }
+  }
+}

--- a/examples/fintech-agent-runner/agents/pm.md
+++ b/examples/fintech-agent-runner/agents/pm.md
@@ -1,0 +1,32 @@
+---
+description: Senior Product Manager. Use to create product delivery roadmap plans aligned with the fintech delivery engine and to materialize them as GitHub milestones and issues. Advisory only — never commits directly.
+mode: subagent
+temperature: 0.3
+permission:
+  edit: allow
+  bash:
+    "gh issue *": "allow"
+    "gh api *": "allow"
+    "git *": "allow"
+    "*": "ask"
+  task:
+    docs-reader: allow
+---
+
+You are a Senior Product Manager agent for a fintech product-delivery engine (PDM — Product Delivery Management, not the Python package manager). You turn a product goal into a delivery roadmap plan and materialize it as GitHub milestones/issues when asked.
+
+## Context first (wiki-first, live)
+
+Fetch the project wiki live via `webfetch` before anything else — ROADMAP, Agent-Guide, Architecture, and the most recent `Plan-*` pages. Never rely on a local cache. Then read `AGENTS.md` and `README.md`, and cross-check against live GitHub state (`gh issue list`, milestones API, `git log --oneline -10`, `git branch --show-current`). Honor the honesty rule: where evidence is missing, report `insufficient-data`, never invent.
+
+## Produce the roadmap
+
+Mirror the wiki ROADMAP structure: Purpose, Current State, Goals/non-goals + DORA-style success metrics, Phases with numbered `P<n>-T<n>` tasks (each tagged with its delivery gates and touchpoints), Acceptance criteria per phase, Execution model, Risks & mitigations, Definition of Done. Stay at the product/delivery level, not code-level implementation detail.
+
+## GitHub-native materialization (milestones + issues, no local changes)
+
+1. Confirm issue granularity and count first.
+2. Milestone per phase, titled `Phase <n>: <name>` — create missing ones only; never touch `v<version>` release milestones.
+3. Duplicate-check open issues before creating.
+4. One issue per task targeting `develop`: title `[P<phase>-T<n>] <concise title>` (**never** headline classifier words — `rollback`/`incident`/`outage`/`hotfix`/`regression` — unless the task genuinely is a failure event), body with goal/acceptance/phase-task ID/gates + link to the wiki plan page, label `pdm-planning`, milestone the phase milestone.
+5. Report URLs; never create issues completely unprompted, never edit/close other issues, never touch workflows.

--- a/examples/fintech-agent-runner/test/agents.test.mjs
+++ b/examples/fintech-agent-runner/test/agents.test.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Fintech agent-runner fleet hygiene test (node --test).
+//
+// Enforces the ADR 0015 scrub rules on the example's agent definitions:
+// - valid YAML frontmatter with `description` + `mode`
+// - `mode` is a valid opencode mode
+// - no model pins, no absolute paths, no secrets/tokens
+// - no failure-classifier words in the description (telemetry honesty)
+// - the runtime config template only references env vars (never literal models)
+//
+// Usage: node --test test/agents.test.mjs
+
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const AGENTS = path.resolve(HERE, "..", "agents");
+
+const VALID_MODES = new Set(["primary", "subagent", "all"]);
+const SECRET_PATTERNS = [
+  /\b(?:secret|token|password|private[_ ]?key|api[_ ]?key)\b\s*[:=]/i,
+  /\bghp_[A-Za-z0-9]{20,}\b/,
+  /\bxox[bap]-[A-Za-z0-9-]{10,}\b/,
+];
+const MODEL_PIN_PATTERNS = [
+  /(?:model|small_model)\s*[:=]\s*["']?[^"'{\s]+\/[^"'{\s]+/,
+  /\b(?:claude|gpt|qwen|llama|deepseek|ollama)\/[^"'{\s]+/i,
+];
+const ABSOLUTE_PATH_PATTERNS = [/\/Users\//, /\/home\//, /[A-Za-z]:\\/];
+const CLASSIFIER_WORDS = /\b(rollback|incident|outage|hotfix|regression)\b/i;
+
+function parseFrontmatter(text) {
+  const m = text.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  const fm = {};
+  for (const line of m[1].split("\n")) {
+    const kv = line.match(/^([A-Za-z_]+):\s*(.*)$/);
+    if (kv) fm[kv[1]] = kv[2];
+  }
+  return fm;
+}
+
+function agentFiles() {
+  return readdirSync(AGENTS)
+    .filter((f) => f.endsWith(".md"))
+    .map((f) => path.join(AGENTS, f));
+}
+
+function runtimeTemplate() {
+  const p = path.join(AGENTS, "opencode.example.json");
+  try {
+    return JSON.parse(readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+test("every agent definition has valid frontmatter with description + mode", () => {
+  const files = agentFiles();
+  assert.ok(files.length >= 3, "expected at least 3 agent definitions");
+  for (const f of files) {
+    const fm = parseFrontmatter(readFileSync(f, "utf8"));
+    assert.ok(fm, `${path.basename(f)} missing YAML frontmatter`);
+    assert.ok(fm.description?.length, `${path.basename(f)} missing description`);
+    assert.ok(
+      VALID_MODES.has(fm.mode),
+      `${path.basename(f)} has invalid mode "${fm.mode}"`,
+    );
+  }
+});
+
+test("agents are scrub-clean (no model pins, absolute paths, secrets, classifier words)", () => {
+  for (const f of agentFiles()) {
+    const text = readFileSync(f, "utf8");
+    const base = path.basename(f);
+    assert.ok(!MODEL_PIN_PATTERNS.some((re) => re.test(text)), `${base}: model pin`);
+    assert.ok(!ABSOLUTE_PATH_PATTERNS.some((re) => re.test(text)), `${base}: absolute path`);
+    assert.ok(!SECRET_PATTERNS.some((re) => re.test(text)), `${base}: secret/token`);
+    const fm = parseFrontmatter(text);
+    assert.ok(
+      !CLASSIFIER_WORDS.test(fm?.description ?? ""),
+      `${base}: failure-classifier word in description`,
+    );
+  }
+});
+
+test("read-only reviewer subagent denies edit + bash", () => {
+  const reviewer = path.join(AGENTS, "compliance-reviewer.md");
+  const text = readFileSync(reviewer, "utf8");
+  assert.match(text, /edit:\s*deny/);
+  assert.match(text, /bash:\s*deny/);
+});
+
+test("runtime config template references env only, never literal models", () => {
+  const cfg = runtimeTemplate();
+  assert.ok(cfg, "agents/opencode.example.json must exist and parse as JSON");
+  assert.equal(cfg.model, "{env:OPENCODE_MODEL}");
+  assert.equal(cfg.small_model, "{env:OPENCODE_SMALL_MODEL}");
+  for (const key of ["model", "small_model"]) {
+    const v = cfg[key];
+    assert.ok(
+      /^\{env:[A-Z_]+\}$/.test(v ?? ""),
+      `config field "${key}" should reference an env var, got "${v}"`,
+    );
+  }
+});

--- a/examples/pdm-workflow-templates/README.md
+++ b/examples/pdm-workflow-templates/README.md
@@ -1,0 +1,38 @@
+# PDM Workflow Templates — ready-to-copy GitHub Actions
+
+Reusable GitHub Actions workflow templates for adopting the PDM delivery gates in a fintech project without writing every workflow from scratch. Each template is kept actionlint-clean by this repo's integration test (`make test-examples`), and follows the repo's hard-earned gotchas: `osv-scanner-action` subdir path, `--recursive .` flag, github-script context without redeclaration, artifact uploads guarded for non-PR runs.
+
+## Templates
+
+| Template | Trigger(s) | What it enforces |
+|---|---|---|
+| `templates/quality-gate.yml` | pull_request (develop/main) + dispatch | actionlint on workflows + code-quality steps behind toolchain detection (the required `main` branch-protection check) |
+| `templates/compliance-guardrail.yml` | pull_request + dispatch | trufflehog base..head secret/compliance scan, pass/fail PR comment (guarded on `pull_request.number`) |
+| `templates/agent-runner.yml` | dispatch only | run an opencode agent fleet step (a `make fleet-sync` + agent-invocation example), artifact upload, no PR trigger by construction |
+
+Reference versions of all three live and verified in this repo under `.github/pdm/workflows/`.
+
+## Adopt in a fresh repo
+
+```sh
+# copy the workflows into your canonical tree (or straight to .github/workflows/)
+mkdir -p .github/pdm/workflows
+cp examples/pdm-workflow-templates/templates/*.yml .github/pdm/workflows/
+
+# if you adopt the canonical -> execution convention:
+make sync        # .github/pdm/workflows/*.yml -> .github/workflows/
+make lint        # actionlint + drift check
+```
+
+- Replace `owner/repo`-specific labels in template comments with your own (the trigger branch lists and gate names match this repo; adapt `branches:` to your default branch).
+- `quality-gate.yml` uses the same toolchain-detection pattern as this repo's gate: it only runs install/lint/typecheck/test/build when a `package.json` + lockfile exist, so it works whether or not your app ships a frontend.
+- `agent-runner.yml` calls `make fleet-sync` — copy the canonical fleet first (see `examples/fintech-agent-runner/`).
+
+## Verification
+
+```sh
+actionlint templates/*.yml   # always clean in this repo; the CI integration test re-checks it
+make test-examples           # runs actionlint + the mock contract checks on these templates
+```
+
+The integration test also parses `on:` triggers to confirm the commented expectations: `agent-runner` has no PR trigger (so its artifact upload needs no guard), while `quality-gate`/`compliance-guardrail` guard their writes on `github.event.pull_request`.

--- a/examples/pdm-workflow-templates/templates/agent-runner.yml
+++ b/examples/pdm-workflow-templates/templates/agent-runner.yml
@@ -1,0 +1,50 @@
+name: PDM Agent Runner (dispatch)
+
+# Template: run the opencode AI agent fleet headlessly from a workflow_dispatch.
+# Demonstrates the ADR 0015 fleet ops loop without a PR trigger — so its
+# artifact upload needs no `github.event.pull_request` guard by construction.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: agent-runner
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  fleet-brief:
+    name: Fleet brief (advisory, dispatch only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install the canonical fleet into the runtime
+        shell: bash
+        run: make fleet-sync
+
+      - name: Run the fleet brief (agent runner)
+        shell: bash
+        run: |
+          if command -v opencode >/dev/null 2>&1; then
+            # Replace with your agent runner of choice (opencode, codex, ...).
+            opencode run "Produce a labeled agent-advisory brief (kind: agent-advisory) and write it to .github/pdm/reports/agent-brief.md"
+          else
+            echo "No agent runner installed on this runner; producing a mock brief."
+            printf '%s\n' \
+              'kind: agent-advisory' \
+              'scope: weekly delivery-health brief' \
+              'payload: mocked - install the fleet runner to produce a real brief.' \
+              > .github/pdm/reports/agent-brief.md
+          fi
+
+      - name: Upload advisory brief
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: agent-brief
+          path: .github/pdm/reports/agent-brief.md
+          retention-days: 7

--- a/examples/pdm-workflow-templates/templates/compliance-guardrail.yml
+++ b/examples/pdm-workflow-templates/templates/compliance-guardrail.yml
@@ -1,0 +1,54 @@
+name: PDM Compliance & Security Guardrail
+
+# Template: shift-left secrets/compliance scanning. Scans the PR base..head with
+# trufflehog and posts a pass/fail comment on PR runs (guarded on
+# context.payload.pull_request.number so non-PR runs never hit the API).
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+  workflow_dispatch:
+
+concurrency:
+  group: compliance-guardrail-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compliance-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Run Secret and Compliance Scanning
+        uses: trufflesecurity/trufflehog@v3.97.0
+        with:
+          base: ${{ github.event.pull_request.base.sha || '4b825dc642cb6eb9a060e54bf8d69288fbee4904' }}
+          head: ${{ github.event.pull_request.head.sha || github.sha }}
+          extra_args: --only-verified
+
+      - name: Post Compliance Status
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const outcome = "${{ job.status }}";
+            const statusBody =
+              outcome === "success"
+                ? "### 🛡️ PDM Compliance Agent\n✅ **Passed:** No hardcoded secrets, data privacy violations, or regulatory compliance flags detected."
+                : "### 🛡️ PDM Compliance Agent\n❌ **Blocked:** Potential security or compliance violation detected in code changes. Please review logs and remediate before merging.";
+
+            if (context.payload.pull_request?.number) {
+              await github.rest.issues.createComment({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: statusBody
+              });
+            }

--- a/examples/pdm-workflow-templates/templates/quality-gate.yml
+++ b/examples/pdm-workflow-templates/templates/quality-gate.yml
@@ -1,0 +1,135 @@
+name: PDM Quality Gate (Status Check)
+
+# Template: required status check for the protected branch. Posts a gate summary
+# comment on PR runs, uploads a gate-report artifact on non-PR runs.
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
+  workflow_dispatch:
+
+concurrency:
+  group: quality-gate-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  workflow-lint:
+    name: Workflow Lint (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install actionlint
+        shell: bash
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- 1.7.12
+
+      - name: Lint all workflows
+        shell: bash
+        run: ./actionlint -color -pyflakes=0
+
+  code-quality:
+    name: Code Quality (lint/typecheck/test/build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Detect frontend toolchain
+        id: detect
+        shell: bash
+        run: |
+          if [[ -f package.json ]]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ -f pnpm-lock.yaml ]]; then
+            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
+          fi
+          for script in lint typecheck test build; do
+            if [[ -f package.json ]] && grep -q "\"$script\":" package.json; then
+              echo "has_${script}=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_${script}=false" >> "$GITHUB_OUTPUT"
+            fi
+          done
+
+      - name: Note when no frontend
+        if: steps.detect.outputs.found != 'true'
+        run: echo "No frontend toolchain detected; code-quality gate passes by default."
+
+      - name: Set up pnpm
+        if: steps.detect.outputs.has_lockfile == 'true'
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.21.0
+
+      - name: Set up Node.js
+        if: steps.detect.outputs.has_lockfile == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        if: steps.detect.outputs.has_lockfile == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        if: steps.detect.outputs.has_lint == 'true'
+        run: pnpm run lint
+
+      - name: Typecheck
+        if: steps.detect.outputs.has_typecheck == 'true'
+        run: pnpm run typecheck
+
+      - name: Test
+        if: steps.detect.outputs.has_test == 'true'
+        run: pnpm test
+
+      - name: Build
+        if: steps.detect.outputs.has_build == 'true'
+        run: pnpm run build
+
+  gate:
+    name: PDM Quality Gate (Status Check)
+    needs: [ workflow-lint, code-quality ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail gate on any upstream failure
+        if: needs.workflow-lint.result == 'failure' || needs.code-quality.result == 'failure'
+        shell: bash
+        run: exit 1
+
+      - name: Persist gate report for non-PR runs
+        if: github.event.pull_request.number == null
+        shell: bash
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/.github/pdm/reports"
+          cat > "$GITHUB_WORKSPACE/.github/pdm/reports/gate-report.md" <<'EOF'
+          ## PDM Quality Gate
+          - **Workflow lint (actionlint)**: ${{ needs.workflow-lint.result }}
+          - **Code quality (lint/typecheck/test/build)**: ${{ needs.code-quality.result }}
+          EOF
+
+      - name: Upload gate report
+        if: always() && github.event.pull_request.number == null
+        uses: actions/upload-artifact@v7
+        with:
+          name: gate-report
+          path: .github/pdm/reports/gate-report.md
+          retention-days: 7

--- a/scripts/examples-test.mjs
+++ b/scripts/examples-test.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Issue #184 — integration test for the examples/templates tree.
+//
+// Runs the example deliverables' offline checks (no GitHub, no Docker):
+//   1. every example subproject has a README + the structure its own test needs
+//   2. the fintech-agent-runner fleet passes its own scrub-rule test
+//   3. the agent-skills-demo contract test passes (mocked "agent runner")
+//   4. the pdm-workflow-templates workflows parse as YAML and pass actionlint
+//   5. template invariants mirror the repo's gotchas: artifact uploads are
+//      guarded for PR-independent runs, or the trigger is dispatch-only
+//
+// Usage: node scripts/examples-test.mjs [--examples <dir>]
+// Exit 0 when every check passes; non-zero with a FAIL matrix otherwise.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const EXAMPLES = path.resolve(
+  process.argv.indexOf("--examples") >= 0
+    ? process.argv[process.argv.indexOf("--examples") + 1]
+    : path.join(ROOT, "examples"),
+);
+
+const RESULTS = [];
+
+function record(id, name, pass, detail = "") {
+  RESULTS.push({ id, name, pass: Boolean(pass), detail });
+  console.log(`${pass ? "PASS" : "FAIL"}  ${id}  ${name}${detail ? `  — ${detail}` : ""}`);
+}
+
+function yamlKey(text, key) {
+  const m = text.match(new RegExp(`^${key}:\\s*(.*)$`, "m"));
+  return m ? m[1] : null;
+}
+
+const subprojects = () =>
+  readdirSync(EXAMPLES, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+    .map((d) => d.name);
+
+// ---- 1. structure: README + expected top-levels ----
+(async () => {
+  const dirs = subprojects();
+  record("E1", "examples/ has >= 2 reference implementations", dirs.length >= 2, dirs.join(", "));
+
+  for (const dir of dirs) {
+    const base = path.join(EXAMPLES, dir);
+    record(
+      `E1-${dir}`,
+      `${dir}/README.md exists with adoption instructions`,
+      existsSync(path.join(base, "README.md")),
+    );
+  }
+
+  // ---- 2. fintech-agent-runner fleet hygiene ----
+  const runner = path.join(EXAMPLES, "fintech-agent-runner");
+  if (existsSync(runner)) {
+    try {
+      execFileSync("node", ["--test", "test/*.test.mjs"], { cwd: runner, stdio: "pipe" });
+      record("E2", "fintech-agent-runner fleet test green (scrub rules, frontmatter)", true);
+    } catch (e) {
+      record("E2", "fintech-agent-runner fleet test green (scrub rules, frontmatter)", false,
+        String(e.stdout ?? e.message).split("\n").slice(-4).join(" "));
+    }
+  } else {
+    record("E2", "fintech-agent-runner fleet test green (scrub rules, frontmatter)", false, "missing subproject");
+  }
+
+  // ---- 3. agent-skills-demo contract (mocked runner) ----
+  const demo = path.join(EXAMPLES, "agent-skills-demo");
+  if (existsSync(demo)) {
+    try {
+      execFileSync("node", ["--test", "test/*.test.mjs"], { cwd: demo, stdio: "pipe" });
+      record("E3", "agent-skills-demo contract test green (mocked runner)", true);
+    } catch (e) {
+      record("E3", "agent-skills-demo contract test green (mocked runner)", false,
+        String(e.stdout ?? e.message).split("\n").slice(-4).join(" "));
+    }
+  } else {
+    record("E3", "agent-skills-demo contract test green (mocked runner)", false, "missing subproject");
+  }
+
+  // ---- 4 + 5. template workflows: YAML parse + actionlint + guard invariants ----
+  const templatesDir = path.join(EXAMPLES, "pdm-workflow-templates", "templates");
+  if (existsSync(templatesDir)) {
+    const ymlFiles = readdirSync(templatesDir).filter((f) => f.endsWith(".yml"));
+    record("E4", "pdm-workflow-templates has >= 1 template workflow", ymlFiles.length >= 1);
+
+    // actionlint is required in the quality-gate step and validates full YAML +
+    // GitHub expressions. Here we do light structural checks first (zero-dep),
+    // then actionlint for the strict parse.
+    let actionlintOk = false;
+    for (const f of ymlFiles) {
+      const abs = path.join(templatesDir, f);
+      const text = readFileSync(abs, "utf8");
+      record(`E4-${f}-has-name`, `${f} has a name:`, /^name:\s*\S/m.test(text));
+      record(`E4-${f}-has-jobs`, `${f} has on: and jobs:`, /^on:\s*$/m.test(text) && /^jobs:\s*$/m.test(text));
+    }
+
+    try {
+      execFileSync("actionlint", ymlFiles.map((f) => path.join("templates", f)),
+        { cwd: path.join(EXAMPLES, "pdm-workflow-templates"), stdio: "pipe" });
+      actionlintOk = true;
+      record("E5", "template workflows pass actionlint", true);
+    } catch (e) {
+      actionlintOk = false;
+      record("E5", "template workflows pass actionlint", false,
+        String(e.stdout ?? e.message).split("\n").slice(-6).join(" "));
+    }
+
+    // Artifact-guard invariant: a PR-triggered workflow that uploads artifacts
+    // must guard on github.event.pull_request (else non-PR runs write to the tree).
+    for (const f of ymlFiles) {
+      const text = readFileSync(path.join(templatesDir, f), "utf8");
+      const uploads = text.includes("upload-artifact");
+      if (!uploads) continue;
+      const prTriggered = /^\s*pull_request:\s*$/m.test(text);
+      const guarded = text.includes("github.event.pull_request");
+      record(
+        `E5-${f}-guards`,
+        `${f} artifact upload ${prTriggered ? "guarded for PR runs" : "dispatch-only (no guard needed)"}`,
+        !prTriggered || guarded,
+      );
+    }
+    void actionlintOk;
+  } else {
+    record("E4", "pdm-workflow-templates has >= 1 template workflow", false, "missing templates/");
+    record("E5", "template workflows pass actionlint", false, "missing templates/");
+  }
+
+  // ---- Report ----
+  const summary = RESULTS.reduce(
+    (acc, r) => ({ pass: acc.pass + Number(r.pass), fail: acc.fail + Number(!r.pass) }),
+    { pass: 0, fail: 0 },
+  );
+  console.log(`\nSummary: ${summary.pass} pass, ${summary.fail} fail`);
+  process.exitCode = summary.fail === 0 ? 0 : 1;
+})();


### PR DESCRIPTION
Closes #184 — Examples and Templates.

## What
- **`examples/`** — 3 reference implementations, each a self-contained subproject with README + adoption `cp` commands:
  - `fintech-agent-runner/` — scrubbed opencode agent fleet (`pm`, `delivery-engineer`, `compliance-reviewer`), `fleet-sync`, hygiene test
  - `pdm-workflow-templates/` — actionlint-valid `quality-gate.yml`, `compliance-guardrail.yml`, `agent-runner.yml` (dispatch-only)
  - `agent-skills-demo/` — skill-resolution demo + dependency-free `node:test` mock-CI scaffold
- **Integration tests in CI** — `scripts/examples-test.mjs` (16 checks: README/structure, fleet scrub rules, template actionlint + artifact-guard invariants, mocked contract test), wired into `quality-gate.yml`'s `workflow-lint` job + `make test-examples`.
- **Docs** — README updated (structure + Makefile table + Examples & Templates section); wiki `Examples-and-Templates` page drafted (separate wiki push).

## Verification
- `make sync` + `make lint` clean (no drift)
- `make test-examples` → 16 pass, 0 fail
- Native gates run on this PR (quality-gate now validates examples too)