### PR TITLE
feat(ci): reusable composite actions, workflow-run telemetry & rollout plan

### DIFF
--- a/.github/actions/pdm-code-quality/action.yml
+++ b/.github/actions/pdm-code-quality/action.yml
@@ -1,0 +1,69 @@
+name: PDM code quality
+description: >-
+  Run the frontend quality scripts (lint/typecheck/test/build) inside a project
+  directory, each gated on whether the project declares the script (pass the
+  has_*_script inputs from setup-pdm-toolchain outputs). A reusable building
+  block for quality gates and code-health jobs across repos.
+inputs:
+  project-dir:
+    description: Directory (relative to the workspace root) holding package.json
+    required: false
+    default: frontend
+  has_lint_script:
+    description: 'true when package.json declares a lint script (setup-pdm-toolchain output)'
+    required: false
+    default: 'false'
+  has_typecheck_script:
+    description: 'true when package.json declares a typecheck script (setup-pdm-toolchain output)'
+    required: false
+    default: 'false'
+  has_test_script:
+    description: 'true when package.json declares a test script (setup-pdm-toolchain output)'
+    required: false
+    default: 'false'
+  has_build_script:
+    description: 'true when package.json declares a build script (setup-pdm-toolchain output)'
+    required: false
+    default: 'false'
+  run-lint:
+    description: 'Set to false to skip the lint step entirely'
+    required: false
+    default: 'true'
+  run-typecheck:
+    description: 'Set to false to skip the typecheck step entirely'
+    required: false
+    default: 'true'
+  run-test:
+    description: 'Set to false to skip the test step entirely'
+    required: false
+    default: 'true'
+  run-build:
+    description: 'Set to false to skip the build step entirely'
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Lint
+      if: inputs.run-lint == 'true' && inputs.has_lint_script == 'true'
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      run: pnpm run lint
+
+    - name: Typecheck
+      if: inputs.run-typecheck == 'true' && inputs.has_typecheck_script == 'true'
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      run: pnpm run typecheck
+
+    - name: Test
+      if: inputs.run-test == 'true' && inputs.has_test_script == 'true'
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      run: pnpm test
+
+    - name: Build
+      if: inputs.run-build == 'true' && inputs.has_build_script == 'true'
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      run: pnpm run build

--- a/.github/actions/setup-pdm-toolchain/action.yml
+++ b/.github/actions/setup-pdm-toolchain/action.yml
@@ -1,0 +1,98 @@
+name: Setup PDM toolchain
+description: >-
+  Detect a pnpm/Node frontend toolchain in a project directory and install it
+  (pnpm + Node with pnpm cache + frozen-lockfile install). Exposes which
+  quality scripts (lint/typecheck/test/build) the project declares so callers
+  can gate each step individually. Factors the duplicated detect blocks that
+  previously lived inline in quality-gate, risk-health-check, and
+  publish-pages.
+inputs:
+  project-dir:
+    description: Directory (relative to the workspace root) holding package.json / pnpm-lock.yaml
+    required: false
+    default: frontend
+  node-version:
+    description: Node.js version to install via actions/setup-node
+    required: false
+    default: '22'
+  pnpm-version:
+    description: pnpm version to install via pnpm/action-setup
+    required: false
+    default: '11.21.0'
+outputs:
+  found:
+    description: 'true when package.json exists in project-dir'
+    value: ${{ steps.detect.outputs.found }}
+  has_lockfile:
+    description: 'true when pnpm-lock.yaml exists in project-dir'
+    value: ${{ steps.detect.outputs.has_lockfile }}
+  has_lint_script:
+    description: 'true when package.json declares a lint script'
+    value: ${{ steps.detect.outputs.has_lint_script }}
+  has_typecheck_script:
+    description: 'true when package.json declares a typecheck script'
+    value: ${{ steps.detect.outputs.has_typecheck_script }}
+  has_test_script:
+    description: 'true when package.json declares a test script'
+    value: ${{ steps.detect.outputs.has_test_script }}
+  has_build_script:
+    description: 'true when package.json declares a build script'
+    value: ${{ steps.detect.outputs.has_build_script }}
+runs:
+  using: composite
+  steps:
+    - name: Detect frontend toolchain
+      id: detect
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      run: |
+        if [[ -f package.json ]]; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -f pnpm-lock.yaml ]]; then
+          echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -f package.json ]] && grep -q '"lint":' package.json; then
+          echo "has_lint_script=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_lint_script=false" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -f package.json ]] && grep -q '"typecheck":' package.json; then
+          echo "has_typecheck_script=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_typecheck_script=false" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -f package.json ]] && grep -q '"test":' package.json; then
+          echo "has_test_script=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_test_script=false" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ -f package.json ]] && grep -q '"build":' package.json; then
+          echo "has_build_script=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "has_build_script=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Set up pnpm
+      if: steps.detect.outputs.has_lockfile == 'true'
+      uses: pnpm/action-setup@v6
+      with:
+        version: ${{ inputs.pnpm-version }}
+
+    - name: Set up Node.js
+      if: steps.detect.outputs.has_lockfile == 'true'
+      uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+        cache-dependency-path: ${{ inputs.project-dir }}/pnpm-lock.yaml
+
+    - name: Install dependencies
+      if: steps.detect.outputs.has_lockfile == 'true'
+      shell: bash
+      working-directory: ${{ inputs.project-dir }}
+      run: pnpm install --frozen-lockfile

--- a/.github/pdm/workflows/delivery-telemetry.yml
+++ b/.github/pdm/workflows/delivery-telemetry.yml
@@ -40,6 +40,16 @@ jobs:
           node scripts/delivery-telemetry.mjs .github/pdm/reports
           ls -la .github/pdm/reports/delivery-*
 
+      - name: Run workflow-run telemetry & cost estimate
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOOKBACK_DAYS: '90'
+        run: |
+          node scripts/workflow-run-telemetry.mjs .github/pdm/reports
+          ls -la .github/pdm/reports/delivery-workflow-runs-*
+
       - name: Upload delivery telemetry & audit trail
         uses: actions/upload-artifact@v7
         with:

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -40,6 +40,11 @@ jobs:
           export PATH="$GITHUB_WORKSPACE:$PATH"
           node scripts/examples-test.mjs
 
+      - name: Run delivery-engine script unit tests
+        shell: bash
+        run: |
+          node --test scripts/test/*.test.mjs
+
   code-quality:
     name: Code Quality (lint/typecheck/test/build)
     runs-on: ubuntu-latest

--- a/.github/pdm/workflows/risk-health-check.yml
+++ b/.github/pdm/workflows/risk-health-check.yml
@@ -91,6 +91,11 @@ jobs:
           else
             echo "has_test_script=false" >> "$GITHUB_OUTPUT"
           fi
+          if [[ -f package.json ]] && grep -q '"build":' package.json; then
+            echo "has_build_script=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_build_script=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Show health summary
         if: steps.detect.outputs.found != 'true'

--- a/.github/workflows/delivery-telemetry.yml
+++ b/.github/workflows/delivery-telemetry.yml
@@ -40,6 +40,16 @@ jobs:
           node scripts/delivery-telemetry.mjs .github/pdm/reports
           ls -la .github/pdm/reports/delivery-*
 
+      - name: Run workflow-run telemetry & cost estimate
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOOKBACK_DAYS: '90'
+        run: |
+          node scripts/workflow-run-telemetry.mjs .github/pdm/reports
+          ls -la .github/pdm/reports/delivery-workflow-runs-*
+
       - name: Upload delivery telemetry & audit trail
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -40,6 +40,11 @@ jobs:
           export PATH="$GITHUB_WORKSPACE:$PATH"
           node scripts/examples-test.mjs
 
+      - name: Run delivery-engine script unit tests
+        shell: bash
+        run: |
+          node --test scripts/test/*.test.mjs
+
   code-quality:
     name: Code Quality (lint/typecheck/test/build)
     runs-on: ubuntu-latest

--- a/.github/workflows/risk-health-check.yml
+++ b/.github/workflows/risk-health-check.yml
@@ -91,6 +91,11 @@ jobs:
           else
             echo "has_test_script=false" >> "$GITHUB_OUTPUT"
           fi
+          if [[ -f package.json ]] && grep -q '"build":' package.json; then
+            echo "has_build_script=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_build_script=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Show health summary
         if: steps.detect.outputs.found != 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PDM_WF    := .github/pdm/workflows
 GH_WF     := .github/workflows
 
-.PHONY: lint sync sync-deps fleet-sync test-frontend test-gh test-consumer-path test-examples test-agent-runner topology-check topology-apply
+.PHONY: lint sync sync-deps fleet-sync test-frontend test-gh test-consumer-path test-examples test-scripts test-agent-runner topology-check topology-apply
 
 # Mirror canonical workflows into .github/workflows (GitHub only executes there)
 sync:
@@ -39,6 +39,9 @@ test-frontend:
 
 # Validate workflow YAML syntax + expressions (no Docker required),
 # and fail if the GitHub execution copies have drifted from canonical.
+# Note: actionlint 1.7.x does NOT lint composite action metadata
+# (.github/actions/*/action.yml) — those are validated structurally by
+# 'make test-examples' (E6), which runs in the quality-gate workflow-lint job.
 lint:
 	actionlint $(PDM_WF)/*.yml $(GH_WF)/*.yml
 	@if diff -r $(PDM_WF) $(GH_WF) >/dev/null 2>&1; then \
@@ -74,9 +77,16 @@ test-consumer-path:
 
 # Issue #184 — validate the examples/ deliverables offline (READMEs + structure,
 # agent scrub-rules, workflow template actionlint + artifact-guard invariants,
-# mocked "agent runner" contract test). Runs in the quality-gate workflow-lint job.
+# composite-action structural checks, mocked "agent runner" contract test).
+# Runs in the quality-gate workflow-lint job.
 test-examples:
 	@node scripts/examples-test.mjs
+
+# Unit tests for the delivery-engine scripts (scripts/test/*.test.mjs) —
+# currently the workflow-run telemetry & cost estimator. Runs in the
+# quality-gate workflow-lint job alongside test-examples.
+test-scripts:
+	@node --test scripts/test/*.test.mjs
 
 # Issue #173 — unit + end-to-end tests for the dry-run AI agent runner
 # (ops/agent-runner): diff parsing, test-scaffold + changelog generation, mock

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository serves as a reference implementation for modern Product Delivery
 
 The delivery engine is **live and operating at cadence** — Phases 0–21 complete, no open gaps:
 
-- **10 canonical workflows** under `.github/pdm/workflows/` (7 core PR/release gates + `publish-pages` + `release-train-simulator` + `copykit-smoke`), mirrored byte-identically to `.github/workflows/` and verified by `make lint`.
+- **11 canonical workflows** under `.github/pdm/workflows/` (8 core PR/release gates + `publish-pages` + `release-train-simulator` + `copykit-smoke`), mirrored byte-identically to `.github/workflows/` and verified by `make lint`.
 - **Releases**: `v0.1.0`, `v0.2.0`, `v0.3.0` shipped via the milestone-gated `release-on-tag` pipeline. Train 2 (departs 08-31, cutoff 08-28) is pending — `v0.3.0` published early, inside train 1's window, so the on-time signal honestly stays 1/1 until a release publishes inside train 2's window `[08-31, 09-14)` (ADR 0009).
 - **Latest truthing readout** (P16-T4, 90d window, run 32115287697): deployment frequency dev 1.79/wk · staging/prod 1.56/wk · pages 2.88/wk; lead time median **6m** (11 PRs); change-failure rate **1.0%** (1/100 — the P10-T2 drill event only); MTTR proxy median **7h 15m** (1 event). The P21 close-out telemetry run (32205889156) confirmed the same numbers unchanged. Full readouts and history: see the [wiki ROADMAP](https://github.com/frdrpo/learning-pdm-fintech-delivery-engine/wiki/ROADMAP).
 - **Release train**: 14-day cadence (ADR 0009); train 3 departs **09-14** (cutoff 09-11), train 4 departs 09-28 — see the [Release Train Calendar](https://github.com/frdrpo/learning-pdm-fintech-delivery-engine/wiki/Release-Train-Calendar).
@@ -25,11 +25,12 @@ All PDM workflow and deployment material is consolidated under a single folder, 
 > **Note:** "PDM" here means Product Delivery Management, not the Python package manager.
 
 - `.github/pdm/workflows/` - Canonical workflow definitions (source of truth).
+  - `ai-agent-mvp.yml` - Issue #173 dry-run AI agent MVP: analyzes TS changes in a PR and posts *suggested* test scaffolds + a changelog snippet as a comment (mocked agent model; never commits).
   - `risk-health-check.yml` - Automates PR size tracking, code complexity analysis, and PDM risk reporting.
   - `compliance-guardrail.yml` - Enforces shift-left security scans and secret detection before code merges.
   - `quality-gate.yml` - Required status check: actionlint on workflows + toolchain-driven lint/test/build, aggregated into a single branch-protection gate.
   - `release-pipeline.yml` - Promotes builds through development/staging/production environments and records dry-run deployments.
-  - `delivery-telemetry.yml` - Exports the GitHub-native delivery audit trail and DORA-style telemetry as run artifacts (weekly + on demand).
+  - `delivery-telemetry.yml` - Exports the GitHub-native delivery audit trail and DORA-style telemetry as run artifacts (weekly + on demand), plus workflow-run metrics and an estimated runner cost (`scripts/workflow-run-telemetry.mjs`).
   - `security-rescan.yml` - Weekly + on-demand gitleaks/OSV re-scan; uploads a report artifact and files an issue on blocking schedule findings.
   - `release-on-tag.yml` - Milestone-gated releases: `workflow_dispatch` with a `version` cuts the release — requires a closed `v<version>` milestone, bumps `frontend/package.json` on `develop`, and opens the release PR `develop → main`. Merging it runs the real `release-pipeline`; a `v*` tag push on `main` publishes the GitHub Release (still milestone-gated).
   - `publish-pages.yml` - Publishes the static-exported frontend to GitHub Pages on every push to `develop` (the live `DEPLOY_VERIFY_URL` target).
@@ -38,6 +39,7 @@ All PDM workflow and deployment material is consolidated under a single folder, 
 - `.github/pdm/deployments/` - Dry-run deployment records uploaded as run artifacts by the release pipeline (not committed).
 - `.github/pdm/reports/` - Risk and quality-gate reports uploaded as run artifacts (not committed).
 - `.github/workflows/` - Mirrored execution copies of `.github/pdm/workflows/`. GitHub only executes workflows from this directory, so keep the copies in sync with `make sync`.
+- `.github/actions/` - Reusable composite actions (`setup-pdm-toolchain`, `pdm-code-quality`) — single-purpose building blocks for quality gates and code-health jobs, referenced by path (`uses: ./.github/actions/<name>`) so no mirroring is needed. Validated structurally by `make test-examples` (E6; actionlint 1.7.x does not lint `action.yml` metadata).
 - `agents/` - The canonical AI agent fleet (ADR 0015): five scrubbed, model-pin-free agent definitions (`pm`, `docs`, `software-engineer`, `junior-software-engineer`, `docs-reader`) installed into a local opencode runtime with `make fleet-sync`. Runtime config (providers/models, keys) stays local — `.opencode/` and `opencode.json` are gitignored; `agents/opencode.example.json` is the scrubbed template (`{env:...}` overridable).
 - `examples/` - Reference implementations and workflow templates for adopting the PDM framework and AI agent patterns (Issue #184): `fintech-agent-runner/` (scrubbed agent fleet + `fleet-sync`), `pdm-workflow-templates/` (actionlint-valid quality-gate/compliance/agent-runner templates), and `agent-skills-demo/` (skill-resolution demo + mocked `node:test` CI scaffold). Validated offline by `make test-examples`, wired into the quality gate.
 - `frontend/` - Next.js 16 website (App Router, TypeScript, Tailwind v4) — a dark fintech landing page with Vitest unit + component tests, plus a `/delivery` route rendering the live delivery-health snapshot (DORA metrics, release-train status, audit trail). This is the application the delivery gates exercise.

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,8 @@ Reference implementations and workflow templates for adopting the PDM framework 
 | [`pdm-workflow-templates/`](pdm-workflow-templates/) | Ready-to-copy GitHub Actions workflow templates: a quality gate, a compliance guardrail, and a `workflow_dispatch` agent-runner job. Validated with actionlint by the integration test. | You want the PR gates in a fresh repo without rewriting the workflows from scratch. |
 | [`agent-skills-demo/`](agent-skills-demo/) | A skill-consumption demo + a dependency-free `node:test` scaffold showing how to add "mocked integration tests that run example workflows in CI." | You want the agent skills pattern plus a no-install test scaffold for validating workflow contracts. |
 
+The repo also ships **reusable composite actions** under `.github/actions/` (`setup-pdm-toolchain`, `pdm-code-quality`) — single-purpose building blocks for any workflow, validated structurally by the integration test (E6). See [`pdm-workflow-templates/README.md`](pdm-workflow-templates/README.md) for the adoption pattern and [`pdm-workflow-templates/ROLLOUT.md`](pdm-workflow-templates/ROLLOUT.md) for the phased migration plan.
+
 ## Adoption path (5 minutes)
 
 1. Pick the subproject that matches your gap (agent fleet, workflow templates, or skills + test scaffold).

--- a/examples/pdm-workflow-templates/README.md
+++ b/examples/pdm-workflow-templates/README.md
@@ -10,7 +10,7 @@ Reusable GitHub Actions workflow templates for adopting the PDM delivery gates i
 | `templates/compliance-guardrail.yml` | pull_request + dispatch | trufflehog base..head secret/compliance scan, pass/fail PR comment (guarded on `pull_request.number`) |
 | `templates/agent-runner.yml` | dispatch only | run an opencode agent fleet step (a `make fleet-sync` + agent-invocation example), artifact upload, no PR trigger by construction |
 
-Reference versions of all three live and verified in this repo under `.github/pdm/workflows/`.
+Reference versions of `quality-gate` and `compliance-guardrail` live and verified in this repo under `.github/pdm/workflows/`. `agent-runner` is dispatch-only by construction (no PR trigger), so it has no direct canonical counterpart — the closest live reference is `ai-agent-mvp.yml` (PR + dispatch, runs the `ops/agent-runner` tests).
 
 ## Adopt in a fresh repo
 
@@ -27,6 +27,43 @@ make lint        # actionlint + drift check
 - Replace `owner/repo`-specific labels in template comments with your own (the trigger branch lists and gate names match this repo; adapt `branches:` to your default branch).
 - `quality-gate.yml` uses the same toolchain-detection pattern as this repo's gate: it only runs install/lint/typecheck/test/build when a `package.json` + lockfile exist, so it works whether or not your app ships a frontend.
 - `agent-runner.yml` calls `make fleet-sync` — copy the canonical fleet first (see `examples/fintech-agent-runner/`).
+
+## Composite actions (reusable building blocks)
+
+Beyond whole-workflow templates, this repo ships reusable **composite actions** under `.github/actions/` — single-purpose building blocks you can drop into any workflow (this repo's or yours) without copying step YAML:
+
+| Action | What it does | Inputs | Outputs |
+|---|---|---|---|
+| `setup-pdm-toolchain` | Detect a pnpm/Node toolchain in a project dir and install it (pnpm + Node with pnpm cache + frozen-lockfile install) | `project-dir` (default `frontend`), `node-version` (22), `pnpm-version` (11.21.0) | `found`, `has_lockfile`, `has_lint_script`, `has_typecheck_script`, `has_test_script`, `has_build_script` |
+| `pdm-code-quality` | Run lint/typecheck/test/build, each gated on whether the project declares the script | `project-dir`, `has_*_script` (from `setup-pdm-toolchain`), `run-lint/typecheck/test/build` toggles | — |
+
+Adopt in a fresh repo:
+
+```sh
+mkdir -p .github/actions
+cp -R ../../.github/actions/setup-pdm-toolchain .github/actions/
+cp -R ../../.github/actions/pdm-code-quality .github/actions/
+```
+
+Consume them from a job (the pattern this repo's rollout plan uses):
+
+```yaml
+jobs:
+  code-quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-pdm-toolchain
+        id: detect
+      - uses: ./.github/actions/pdm-code-quality
+        with:
+          has_lint_script: ${{ steps.detect.outputs.has_lint_script }}
+          has_typecheck_script: ${{ steps.detect.outputs.has_typecheck_script }}
+          has_test_script: ${{ steps.detect.outputs.has_test_script }}
+          has_build_script: ${{ steps.detect.outputs.has_build_script }}
+```
+
+Composite actions are validated structurally by `make test-examples` (E6) — actionlint 1.7.x does not lint `action.yml` metadata — and `make lint` keeps the workflow trees drift-free. See [`ROLLOUT.md`](ROLLOUT.md) for the phased migration plan.
 
 ## Verification
 

--- a/examples/pdm-workflow-templates/ROLLOUT.md
+++ b/examples/pdm-workflow-templates/ROLLOUT.md
@@ -1,0 +1,75 @@
+# Rollout Plan — Migrating PDM Workflows to Reusable Templates & Composite Actions
+
+Task card: *Generalize and scale the repository's automated workflows and GitHub Action runners to support reusable, enterprise-grade CI/CD patterns across fintech delivery projects.*
+
+This plan phases the migration from inline, per-workflow steps to the reusable building blocks shipped in this repo:
+
+- **Composite actions** under `.github/actions/` — `setup-pdm-toolchain` (toolchain detect + install) and `pdm-code-quality` (gated lint/typecheck/test/build). Single canonical location, referenced by path (`uses: ./.github/actions/<name>`), so **no mirroring is needed** — `make sync` is untouched by their adoption.
+- **Workflow templates** under `examples/pdm-workflow-templates/templates/` — copy-me whole-workflow patterns for fresh repos.
+
+Every phase is gated on the existing deterministic gates: `make lint` (actionlint + drift), `make test-examples` (E1–E7 incl. composite-action structural checks), `make test-scripts` (script unit tests), `make test-frontend`, and a native `make test-gh` PR to `develop` that runs the real quality gates.
+
+## Phase 1 — Ship the reusable building blocks (this change)
+
+- [x] Add `.github/actions/setup-pdm-toolchain` and `.github/actions/pdm-code-quality` composite actions.
+- [x] Extend `scripts/examples-test.mjs` with E6 (composite-action structural validation — actionlint 1.7.x cannot lint `action.yml` metadata) and E7 (canonical workflows only reference actions that exist).
+- [x] Add `make test-scripts` for `scripts/test/*.test.mjs`; wire both into the `quality-gate` `workflow-lint` job.
+- [x] Instrument workflow-run telemetry + cost estimates (`scripts/workflow-run-telemetry.mjs`, wired into `delivery-telemetry.yml`).
+- [x] Fix consistency drift found during research: `risk-health-check` detect block now also detects `build` (parity with `quality-gate`), README workflow count 10 → 11 (`ai-agent-mvp.yml`), templates README no longer claims a canonical `agent-runner` counterpart.
+
+**Gate:** `make lint` + `make test-examples` + `make test-scripts` + `make test-frontend` + native PR.
+
+## Phase 2 — Migrate the duplicated toolchain blocks to `setup-pdm-toolchain`
+
+The detect+install block is currently duplicated in three canonical workflows:
+
+| Workflow | Inline block | Replace with |
+|---|---|---|
+| `quality-gate.yml` `code-quality` job | detect + pnpm/Node/install + lint/typecheck/test/build | `setup-pdm-toolchain` + `pdm-code-quality` |
+| `risk-health-check.yml` `code-health` job | detect + pnpm/Node/install + lint/typecheck/test | `setup-pdm-toolchain` (build detection now present) + `pdm-code-quality` with `run-build: 'false'` |
+| `publish-pages.yml` `build` job | detect + pnpm/Node/install + build | `setup-pdm-toolchain` (extra outputs unused) + build step |
+
+Steps per workflow:
+1. Replace the `Detect frontend toolchain` step with `uses: ./.github/actions/setup-pdm-toolchain` (id: `detect`), keeping the same step id so downstream `steps.detect.outputs.*` references keep working.
+2. Delete the now-redundant pnpm/Node/install steps (the action does them).
+3. Replace the gated quality steps with `uses: ./.github/actions/pdm-code-quality`, passing the `has_*_script` outputs.
+4. `make sync` + `make lint` + native PR; verify the gate behaves identically (the PR quality gate is the parity check).
+
+**Gate:** native PR green with identical gate conclusions; `make lint` drift-free.
+
+## Phase 3 — Extend the template inventory
+
+Add whole-workflow templates for the patterns still missing from `examples/pdm-workflow-templates/templates/`:
+
+- `security-scan.yml` — gitleaks + OSV scan capturing the hard-earned gotchas (`google/osv-scanner-action/osv-scanner-action@v2.5.0`, `scan-args: --recursive .`, `hashFiles` gating).
+- `delivery-telemetry.yml` — the DORA + workflow-run telemetry exporter pattern.
+
+Pin the expected inventory in `scripts/examples-test.mjs` (E4) so a stale/renamed template fails the gate.
+
+**Gate:** `make test-examples` with the new inventory pins; actionlint clean.
+
+## Phase 4 — Publish adoption + telemetry docs
+
+- Wiki page `[[Workflow-Templates-Rollout]]` (docs are wiki-only, ADR 0013) linking the composite-action inputs/outputs, the template adoption path, and the rollout phases.
+- Wiki page `[[Telemetry-and-Cost]]` documenting the workflow-run metrics and the cost-estimate assumptions (sampled run minutes × published `ubuntu-latest` rate; public repos free; `insufficient-data` when the API is unreachable).
+- Update `README.md` links and the `examples/` READMEs to point at both pages.
+
+**Gate:** docs reviewed by the `docs` agent; links resolve.
+
+## Phase 5 — Enterprise hardening (follow-ups)
+
+- Optional dispatch-only self-test workflow that runs each composite action against fixture workspaces (only if mocked coverage proves insufficient).
+- Optional `pdm-compliance-scan` composite action (thin trufflehog wrapper) once a second consumer appears — avoid over-engineering today.
+- Revisit `RUNNER_COST_PER_MINUTE` and the sampling window as real billing data becomes available.
+
+**Gate:** each item lands as its own PR through the standard gates.
+
+## Acceptance criteria mapping
+
+| Task-card deliverable | Where it lands |
+|---|---|
+| Reusable templates/composite actions under `.github/actions` or `.github/workflows/templates` | `.github/actions/` (Phase 1) + `examples/pdm-workflow-templates/templates/` (Phase 3) |
+| Docs + examples for adopting in other repos | `examples/` READMEs + wiki pages (Phase 4) |
+| Tests/linting for composite actions + workflows; sample CI job validating templates | E6/E7 + `make test-scripts` wired into the `quality-gate` `workflow-lint` job (Phase 1) |
+| Telemetry: workflow-run metrics + cost estimates documented | `scripts/workflow-run-telemetry.mjs` + `delivery-telemetry.yml` + wiki (Phases 1, 4) |
+| Rollout plan for migrating existing workflows to templates | This document (Phases 1–5) |

--- a/scripts/examples-test.mjs
+++ b/scripts/examples-test.mjs
@@ -8,6 +8,10 @@
 //   4. the pdm-workflow-templates workflows parse as YAML and pass actionlint
 //   5. template invariants mirror the repo's gotchas: artifact uploads are
 //      guarded for PR-independent runs, or the trigger is dispatch-only
+//   6. composite actions under .github/actions/ are structurally valid
+//      (actionlint 1.7.x does NOT lint action.yml metadata, so this is a
+//      structural check: name/description/runs.using/inputs/outputs schema)
+//   7. canonical workflows only reference composite actions that exist
 //
 // Usage: node scripts/examples-test.mjs [--examples <dir>]
 // Exit 0 when every check passes; non-zero with a FAIL matrix otherwise.
@@ -31,18 +35,33 @@ function record(id, name, pass, detail = "") {
   console.log(`${pass ? "PASS" : "FAIL"}  ${id}  ${name}${detail ? `  — ${detail}` : ""}`);
 }
 
-function yamlKey(text, key) {
-  const m = text.match(new RegExp(`^${key}:\\s*(.*)$`, "m"));
-  return m ? m[1] : null;
-}
-
 const subprojects = () =>
   readdirSync(EXAMPLES, { withFileTypes: true })
     .filter((d) => d.isDirectory() && !d.name.startsWith("."))
     .map((d) => d.name);
 
+const finish = () => {
+  const summary = RESULTS.reduce(
+    (acc, r) => ({ pass: acc.pass + Number(r.pass), fail: acc.fail + Number(!r.pass) }),
+    { pass: 0, fail: 0 },
+  );
+  console.log(`\nSummary: ${summary.pass} pass, ${summary.fail} fail`);
+  process.exitCode = summary.fail === 0 ? 0 : 1;
+};
+
 // ---- 1. structure: README + expected top-levels ----
 (async () => {
+  if (!existsSync(EXAMPLES)) {
+    record("E1", "examples/ has >= 2 reference implementations", false, "examples/ missing");
+    record("E2", "fintech-agent-runner fleet test green (scrub rules, frontmatter)", false, "examples/ missing");
+    record("E3", "agent-skills-demo contract test green (mocked runner)", false, "examples/ missing");
+    record("E4", "pdm-workflow-templates has >= 1 template workflow", false, "examples/ missing");
+    record("E5", "template workflows pass actionlint", false, "examples/ missing");
+    record("E6", ".github/actions/ has >= 1 composite action", false, "examples/ missing");
+    record("E7", "canonical workflows reference existing composite actions", false, "examples/ missing");
+    finish();
+    return;
+  }
   const dirs = subprojects();
   record("E1", "examples/ has >= 2 reference implementations", dirs.length >= 2, dirs.join(", "));
 
@@ -92,7 +111,6 @@ const subprojects = () =>
     // actionlint is required in the quality-gate step and validates full YAML +
     // GitHub expressions. Here we do light structural checks first (zero-dep),
     // then actionlint for the strict parse.
-    let actionlintOk = false;
     for (const f of ymlFiles) {
       const abs = path.join(templatesDir, f);
       const text = readFileSync(abs, "utf8");
@@ -103,10 +121,8 @@ const subprojects = () =>
     try {
       execFileSync("actionlint", ymlFiles.map((f) => path.join("templates", f)),
         { cwd: path.join(EXAMPLES, "pdm-workflow-templates"), stdio: "pipe" });
-      actionlintOk = true;
       record("E5", "template workflows pass actionlint", true);
     } catch (e) {
-      actionlintOk = false;
       record("E5", "template workflows pass actionlint", false,
         String(e.stdout ?? e.message).split("\n").slice(-6).join(" "));
     }
@@ -125,17 +141,86 @@ const subprojects = () =>
         !prTriggered || guarded,
       );
     }
-    void actionlintOk;
   } else {
     record("E4", "pdm-workflow-templates has >= 1 template workflow", false, "missing templates/");
     record("E5", "template workflows pass actionlint", false, "missing templates/");
   }
 
-  // ---- Report ----
-  const summary = RESULTS.reduce(
-    (acc, r) => ({ pass: acc.pass + Number(r.pass), fail: acc.fail + Number(!r.pass) }),
-    { pass: 0, fail: 0 },
+  // ---- 6. composite actions under .github/actions/ ----
+  // actionlint 1.7.x treats action.yml as a workflow and rejects composite
+  // metadata, so composite actions get structural checks instead: required
+  // keys, runs.using: composite, >= 1 step, and inputs/outputs schema.
+  const actionsDir = path.join(ROOT, ".github", "actions");
+  const actionDirs = existsSync(actionsDir)
+    ? readdirSync(actionsDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && !d.name.startsWith("."))
+        .map((d) => d.name)
+    : [];
+  record("E6", ".github/actions/ has >= 1 composite action", actionDirs.length >= 1, actionDirs.join(", ") || "missing");
+
+  const blockAfter = (text, key) => {
+    const m = text.match(new RegExp(`^${key}:\\s*$\\n([\\s\\S]*?)(?=^\\S|$)`));
+    return m ? m[1] : "";
+  };
+  const keyLines = (block) => [...block.matchAll(/^\s{2}(\S[^:]*):\s*$/gm)].map((m) => m[1]);
+
+  for (const name of actionDirs) {
+    const actionFile = path.join(actionsDir, name, "action.yml");
+    if (!existsSync(actionFile)) {
+      record(`E6-${name}-file`, `${name}/action.yml exists`, false, "missing action.yml");
+      continue;
+    }
+    const text = readFileSync(actionFile, "utf8");
+    record(`E6-${name}-name`, `${name} has name:`, /^name:\s*\S/m.test(text));
+    record(`E6-${name}-desc`, `${name} has description:`, /^description:\s*\S/m.test(text));
+    record(
+      `E6-${name}-composite`,
+      `${name} is a composite action (runs.using: composite)`,
+      /^runs:\s*$/m.test(text) && /using:\s*composite/.test(text),
+    );
+    record(`E6-${name}-steps`, `${name} has >= 1 step`, /^\s+- name:\s*\S/m.test(text));
+
+    const inputKeys = keyLines(blockAfter(text, "inputs"));
+    const outputKeys = keyLines(blockAfter(text, "outputs"));
+    if (inputKeys.length > 0) {
+      const inputBlock = blockAfter(text, "inputs");
+      record(
+        `E6-${name}-inputs`,
+        `${name} inputs each have a description`,
+        inputKeys.every((k) => new RegExp(`^\\s{4}description:`).test(inputBlock)),
+      );
+    }
+    if (outputKeys.length > 0) {
+      const outputBlock = blockAfter(text, "outputs");
+      record(
+        `E6-${name}-outputs`,
+        `${name} outputs each have a value`,
+        outputKeys.every((k) => new RegExp(`^\\s{4}value:`).test(outputBlock)),
+      );
+    }
+  }
+
+  // ---- 7. canonical workflows only reference actions that exist ----
+  const canonicalDir = path.join(ROOT, ".github", "pdm", "workflows");
+  const wfFiles = existsSync(canonicalDir)
+    ? readdirSync(canonicalDir).filter((f) => f.endsWith(".yml"))
+    : [];
+  const actionRefs = [];
+  for (const f of wfFiles) {
+    const text = readFileSync(path.join(canonicalDir, f), "utf8");
+    for (const m of text.matchAll(/uses:\s*\.\/\.github\/actions\/([\w-]+)/g)) {
+      actionRefs.push({ file: f, action: m[1] });
+    }
+  }
+  record(
+    "E7",
+    "canonical workflows reference existing composite actions",
+    actionRefs.every((r) => existsSync(path.join(actionsDir, r.action, "action.yml"))),
+    actionRefs.length === 0
+      ? "no references yet (vacuous until rollout phase 2)"
+      : actionRefs.map((r) => `${r.file}->${r.action}`).join(", "),
   );
-  console.log(`\nSummary: ${summary.pass} pass, ${summary.fail} fail`);
-  process.exitCode = summary.fail === 0 ? 0 : 1;
+
+  // ---- Report ----
+  finish();
 })();

--- a/scripts/test/workflow-run-telemetry.test.mjs
+++ b/scripts/test/workflow-run-telemetry.test.mjs
@@ -1,0 +1,95 @@
+// Unit tests for scripts/workflow-run-telemetry.mjs (workflow-run metrics +
+// cost estimator). Pure-function tests with fixture run data — no network.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  computeRunMetrics,
+  formatReport,
+  DEFAULT_COST_PER_MINUTE,
+} from '../workflow-run-telemetry.mjs';
+
+const WINDOW = '2026-05-21T00:00:00.000Z';
+
+const run = (overrides) => ({
+  id: 1,
+  name: 'PDM Quality Gate (Status Check)',
+  workflow_id: 123,
+  run_number: 1,
+  head_branch: 'develop',
+  conclusion: 'success',
+  run_started_at: '2026-06-01T10:00:00.000Z',
+  updated_at: '2026-06-01T10:05:00.000Z',
+  ...overrides,
+});
+
+test('computeRunMetrics groups runs per workflow and derives durations', () => {
+  const runs = [
+    run({ id: 1, workflow_id: 123, name: 'Gate', run_started_at: '2026-06-01T10:00:00Z', updated_at: '2026-06-01T10:05:00Z', conclusion: 'success' }),
+    run({ id: 2, workflow_id: 123, name: 'Gate', run_started_at: '2026-06-02T10:00:00Z', updated_at: '2026-06-02T10:07:00Z', conclusion: 'failure' }),
+    run({ id: 3, workflow_id: 456, name: 'Pages', run_started_at: '2026-06-03T10:00:00Z', updated_at: '2026-06-03T10:03:00Z', conclusion: 'success' }),
+  ];
+  const m = computeRunMetrics(runs, { windowStartIso: WINDOW, costPerMinute: DEFAULT_COST_PER_MINUTE });
+
+  assert.equal(m.status, 'computed');
+  assert.equal(m.totals.runs, 3);
+  assert.equal(m.totals.minutes, 15); // 5 + 7 + 3
+  assert.equal(m.workflows['123'].name, 'Gate');
+  assert.equal(m.workflows['123'].runs, 2);
+  assert.equal(m.workflows['123'].success, 1);
+  assert.equal(m.workflows['123'].failure, 1);
+  assert.equal(m.workflows['123'].median_minutes, 6); // median of [5, 7]
+  assert.equal(m.workflows['456'].runs, 1);
+  assert.equal(m.workflows['456'].median_minutes, 3);
+});
+
+test('computeRunMetrics ignores runs outside the lookback window', () => {
+  const runs = [
+    run({ id: 1, workflow_id: 123, run_started_at: '2026-01-01T10:00:00Z', updated_at: '2026-01-01T10:05:00Z' }),
+    run({ id: 2, workflow_id: 123, run_started_at: '2026-06-10T10:00:00Z', updated_at: '2026-06-10T10:05:00Z' }),
+  ];
+  const m = computeRunMetrics(runs, { windowStartIso: WINDOW, costPerMinute: DEFAULT_COST_PER_MINUTE });
+  assert.equal(m.totals.runs, 1);
+  assert.equal(m.workflows['123'].runs, 1);
+});
+
+test('computeRunMetrics reports insufficient-data when the API is unreachable', () => {
+  const m = computeRunMetrics(null, { windowStartIso: WINDOW, costPerMinute: DEFAULT_COST_PER_MINUTE });
+  assert.equal(m.status, 'insufficient-data');
+  assert.match(m.note, /unreachable/i);
+});
+
+test('computeRunMetrics handles an empty run list with zero cost', () => {
+  const m = computeRunMetrics([], { windowStartIso: WINDOW, costPerMinute: DEFAULT_COST_PER_MINUTE });
+  assert.equal(m.status, 'computed');
+  assert.equal(m.totals.runs, 0);
+  assert.equal(m.totals.minutes, 0);
+  assert.equal(m.cost_estimate.usd, 0);
+});
+
+test('computeRunMetrics estimates cost from total minutes at the configured rate', () => {
+  const runs = [
+    run({ id: 1, workflow_id: 123, run_started_at: '2026-06-01T10:00:00Z', updated_at: '2026-06-01T10:10:00Z' }),
+  ];
+  const m = computeRunMetrics(runs, { windowStartIso: WINDOW, costPerMinute: 0.5 });
+  assert.equal(m.totals.minutes, 10);
+  assert.equal(m.cost_estimate.usd, 5);
+  assert.equal(m.cost_estimate.rate_per_minute, 0.5);
+});
+
+test('formatReport renders the cost section with documented assumptions', () => {
+  const m = computeRunMetrics(
+    [run({ id: 1, workflow_id: 123, name: 'Gate', run_started_at: '2026-06-01T10:00:00Z', updated_at: '2026-06-01T10:05:00Z' })],
+    { windowStartIso: WINDOW, costPerMinute: DEFAULT_COST_PER_MINUTE },
+  );
+  const report = formatReport(m, { ts: '2026060110', lookbackDays: 90 });
+  assert.match(report, /Workflow-run metrics & cost estimate/);
+  assert.match(report, /Gate/);
+  assert.match(report, /estimated/i);
+  assert.match(report, /assumption/i);
+});
+
+test('formatReport renders insufficient-data honestly', () => {
+  const m = computeRunMetrics(null, { windowStartIso: WINDOW, costPerMinute: DEFAULT_COST_PER_MINUTE });
+  const report = formatReport(m, { ts: '2026060110', lookbackDays: 90 });
+  assert.match(report, /insufficient-data/i);
+});

--- a/scripts/workflow-run-telemetry.mjs
+++ b/scripts/workflow-run-telemetry.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// Workflow-run telemetry & cost estimator.
+//
+// Usage: node scripts/workflow-run-telemetry.mjs <outdir>
+//
+// Reads GitHub Actions workflow runs via the REST API and derives per-workflow
+// run counts, durations, success rates, and an estimated runner cost. Writes:
+//
+//   delivery-workflow-runs-<ts>.json   per-workflow metrics + cost estimate
+//   delivery-workflow-runs-<ts>.md     human-readable report section
+//
+// Env:
+//   GITHUB_TOKEN            required — repo read access (the default actions token)
+//   GITHUB_REPOSITORY       owner/repo (set natively by GitHub Actions)
+//   GITHUB_API_URL          API base, defaults to https://api.github.com
+//   LOOKBACK_DAYS           measurement window, default 90
+//   RUNNER_COST_PER_MINUTE  estimated USD per runner-minute, default 0.008
+//                           (GitHub-hosted ubuntu-latest private-repo rate;
+//                           public repos run free — see the wiki Telemetry page)
+//
+// Cost is an ESTIMATE, never an API number: the org billing endpoint needs
+// elevated tokens, so we multiply sampled run minutes by the published rate
+// and document the assumptions. When the runs API is unreachable the report
+// says insufficient-data rather than inventing numbers (telemetry-honesty).
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+export const DEFAULT_COST_PER_MINUTE = 0.008;
+
+const median = (nums) => {
+  if (nums.length === 0) return null;
+  const sorted = nums.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+
+// Derive per-workflow run metrics + a cost estimate from a list of workflow
+// runs (the GitHub Actions "list workflow runs" payload). `runs` is null when
+// the API was unreachable — the caller then gets an honest insufficient-data
+// result instead of invented numbers.
+export function computeRunMetrics(runs, { windowStartIso, costPerMinute = DEFAULT_COST_PER_MINUTE }) {
+  if (runs === null) {
+    return { status: 'insufficient-data', note: 'workflow-runs API unreachable', workflows: {}, totals: {}, cost_estimate: null };
+  }
+
+  const windowStart = new Date(windowStartIso).getTime();
+  const inWindow = runs.filter((r) => r.run_started_at && new Date(r.run_started_at).getTime() >= windowStart);
+
+  const byWorkflow = new Map();
+  for (const r of inWindow) {
+    const key = String(r.workflow_id);
+    if (!byWorkflow.has(key)) {
+      byWorkflow.set(key, { id: key, name: r.name || `workflow ${key}`, durations: [], success: 0, failure: 0, other: 0 });
+    }
+    const wf = byWorkflow.get(key);
+    const started = new Date(r.run_started_at).getTime();
+    const updated = new Date(r.updated_at || r.run_started_at).getTime();
+    const minutes = Math.max(0, (updated - started) / 60000);
+    wf.durations.push(minutes);
+    if (r.conclusion === 'success') wf.success += 1;
+    else if (r.conclusion === 'failure') wf.failure += 1;
+    else wf.other += 1;
+  }
+
+  const workflows = Object.fromEntries(
+    [...byWorkflow.entries()].map(([key, wf]) => [
+      key,
+      {
+        name: wf.name,
+        runs: wf.durations.length,
+        success: wf.success,
+        failure: wf.failure,
+        other: wf.other,
+        total_minutes: Number(wf.durations.reduce((a, b) => a + b, 0).toFixed(2)),
+        median_minutes: median(wf.durations) === null ? null : Number(median(wf.durations).toFixed(2)),
+      },
+    ]),
+  );
+
+  const totalMinutes = Object.values(workflows).reduce((a, w) => a + w.total_minutes, 0);
+  const totalRuns = Object.values(workflows).reduce((a, w) => a + w.runs, 0);
+  const totalSuccess = Object.values(workflows).reduce((a, w) => a + w.success, 0);
+
+  return {
+    status: 'computed',
+    workflows,
+    totals: {
+      runs: totalRuns,
+      minutes: Number(totalMinutes.toFixed(2)),
+      success: totalSuccess,
+      success_rate: totalRuns === 0 ? null : Number((totalSuccess / totalRuns).toFixed(3)),
+    },
+    cost_estimate: {
+      usd: Number((totalMinutes * costPerMinute).toFixed(2)),
+      rate_per_minute: costPerMinute,
+      note: 'estimate: sampled run minutes x published GitHub-hosted ubuntu-latest rate; public repos run free',
+    },
+  };
+}
+
+export function formatReport(metrics, { ts, lookbackDays }) {
+  if (metrics.status === 'insufficient-data') {
+    return [
+      '### Workflow-run metrics & cost estimate',
+      '',
+      `  - _insufficient-data: ${metrics.note} — no workflow-run data this window._`,
+      '',
+    ].join('\n');
+  }
+
+  const wfLines = Object.values(metrics.workflows).map(
+    (w) =>
+      `  - **${w.name}**: ${w.runs} run(s) — median ${w.median_minutes ?? 'n/a'}m, total ${w.total_minutes}m (${w.success} success / ${w.failure} failure / ${w.other} other)`,
+  );
+
+  return [
+    '### Workflow-run metrics & cost estimate',
+    '',
+    `_Sampled from the GitHub Actions runs API (most recent 100 runs, last ${lookbackDays} days). Durations are run_started_at → updated_at; cost is an estimate with documented assumptions, not a billing figure._`,
+    '',
+    ...(wfLines.length > 0 ? wfLines : ['  - _No workflow runs recorded in the window._']),
+    '',
+    `  - **Total**: ${metrics.totals.runs} run(s), ${metrics.totals.minutes}m — success rate ${metrics.totals.success_rate === null ? 'n/a' : `${(metrics.totals.success_rate * 100).toFixed(1)}%`}`,
+    `  - **Estimated cost**: $${metrics.cost_estimate.usd.toFixed(2)} at $${metrics.cost_estimate.rate_per_minute}/min (${metrics.cost_estimate.note})`,
+    '',
+    `_Raw metrics: \`delivery-workflow-runs-${ts}.json\`._`,
+    '',
+  ].join('\n');
+}
+
+async function ghGet(apiBase, token, pathname) {
+  const resp = await fetch(`${apiBase}${pathname}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'pdm-workflow-run-telemetry',
+    },
+  });
+  if (!resp.ok) {
+    console.warn(`WARN: ${pathname} -> ${resp.status} ${resp.statusText}`);
+    return null;
+  }
+  return resp.json();
+}
+
+export async function fetchWorkflowRuns({ apiBase, owner, repo, token, windowStartIso }) {
+  const created = encodeURIComponent(`>=${windowStartIso}`);
+  const data = await ghGet(apiBase, token, `/repos/${owner}/${repo}/actions/runs?per_page=100&created=${created}`);
+  return data && Array.isArray(data.workflow_runs) ? data.workflow_runs : null;
+}
+
+async function main() {
+  const outDir = process.argv[2];
+  if (!outDir) {
+    console.error('usage: node scripts/workflow-run-telemetry.mjs <outdir>');
+    process.exit(2);
+  }
+  mkdirSync(outDir, { recursive: true });
+
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const lookbackDays = Number(process.env.LOOKBACK_DAYS || 90) || 90;
+  const costPerMinute = Number(process.env.RUNNER_COST_PER_MINUTE || DEFAULT_COST_PER_MINUTE) || DEFAULT_COST_PER_MINUTE;
+
+  if (!token || !repository) {
+    console.error('GITHUB_TOKEN and GITHUB_REPOSITORY are required.');
+    process.exit(2);
+  }
+
+  const apiBase = (process.env.GITHUB_API_URL || 'https://api.github.com').replace(/\/$/, '');
+  const [owner, repo] = repository.split('/');
+  const now = new Date();
+  const windowStartIso = new Date(now.getTime() - lookbackDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const runs = await fetchWorkflowRuns({ apiBase, owner, repo, token, windowStartIso });
+  const metrics = computeRunMetrics(runs, { windowStartIso, costPerMinute });
+  const ts = now.toISOString().replace(/[:.]/g, '').slice(0, 13);
+
+  writeFileSync(`${outDir}/delivery-workflow-runs-${ts}.json`, JSON.stringify(metrics, null, 2) + '\n');
+  writeFileSync(`${outDir}/delivery-workflow-runs-${ts}.md`, formatReport(metrics, { ts, lookbackDays }));
+  console.log(`Wrote delivery-workflow-runs-${ts}.json/.md`);
+  console.log(`workflow_runs=${metrics.totals.runs ?? 'n/a'}`);
+  console.log(`workflow_run_minutes=${metrics.totals.minutes ?? 'n/a'}`);
+  console.log(`estimated_cost_usd=${metrics.cost_estimate ? metrics.cost_estimate.usd : 'n/a'}`);
+}
+
+const isCli = process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+if (isCli) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Generalizes the delivery engine's automation into reusable, enterprise-grade CI/CD patterns (task card: reusable workflow templates/composite actions for fintech delivery projects).

## Deliverables

**1. Reusable composite actions** — `.github/actions/` (single canonical location, reference by path, no mirroring):
- `setup-pdm-toolchain` — factors the detect+install block duplicated across `quality-gate`, `risk-health-check`, `publish-pages`; outputs `found`, `has_lockfile`, `has_{lint,typecheck,test,build}_script`.
- `pdm-code-quality` — gated lint/typecheck/test/build runner consuming the `has_*_script` outputs.

**2. Adopt-in-other-repos docs** — composite-action section in `examples/pdm-workflow-templates/README.md` (inputs/outputs + consume pattern), examples README, main README structure list.

**3. Tests & linting** — `scripts/examples-test.mjs` gains E6 (composite-action structural validation — actionlint 1.7.12 cannot lint `action.yml` metadata) and E7 (canonical workflows only reference existing actions); new `make test-scripts` target (7 unit tests) wired into the `quality-gate` `workflow-lint` CI job.

**4. Telemetry: workflow-run metrics + cost estimates** — `scripts/workflow-run-telemetry.mjs` (per-workflow runs, median/total durations, success rate, estimated runner cost; honest `insufficient-data` on API failure), wired into `delivery-telemetry.yml`.

**5. Rollout plan** — `examples/pdm-workflow-templates/ROLLOUT.md`: phased migration (5 phases) of the existing workflows onto the reusable blocks, each gated on the deterministic gates + a native PR.

## Consistency fixes (from junior-engineer research)
- `risk-health-check` detect block now also detects `build` (parity with `quality-gate`).
- README canonical workflow count 10 -> 11 (`ai-agent-mvp.yml` was unlisted).
- Templates README no longer claims a canonical `agent-runner` counterpart.

## Local gates (pre-PR)
- `make lint` — actionlint + drift: clean (execution copies synced via `make sync`).
- `make test-examples` — E1-E7: 26 pass, 0 fail.
- `make test-scripts` — 7 pass, 0 fail.
- `make test-frontend` — 14 files / 126 tests, build OK.

Phase 2 of the rollout (migrating canonical workflows onto the composite actions) is deliberately a follow-up; E7 is vacuous-pass until then.