### PR TITLE
feat(ci): migrate PDM workflows to composite actions (Issue #185, Phase 2)

### DIFF
--- a/.github/pdm/workflows/publish-pages.yml
+++ b/.github/pdm/workflows/publish-pages.yml
@@ -32,36 +32,7 @@ jobs:
 
       - name: Detect frontend toolchain
         id: detect
-        shell: bash
-        run: |
-          if [[ -f package.json ]]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f pnpm-lock.yaml ]]; then
-            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up pnpm
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.21.0
-
-      - name: Set up Node.js
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install dependencies
-        if: steps.detect.outputs.has_lockfile == 'true'
-        run: pnpm install --frozen-lockfile
+        uses: ./.github/actions/setup-pdm-toolchain
 
       - name: Build static export
         if: steps.detect.outputs.found == 'true'

--- a/.github/pdm/workflows/quality-gate.yml
+++ b/.github/pdm/workflows/quality-gate.yml
@@ -57,76 +57,19 @@ jobs:
 
       - name: Detect frontend toolchain
         id: detect
-        shell: bash
-        run: |
-          if [[ -f package.json ]]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f pnpm-lock.yaml ]]; then
-            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"lint":' package.json; then
-            echo "has_lint_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lint_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"typecheck":' package.json; then
-            echo "has_typecheck_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_typecheck_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"test":' package.json; then
-            echo "has_test_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_test_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"build":' package.json; then
-            echo "has_build_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_build_script=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/setup-pdm-toolchain
 
       - name: Note when no frontend
         if: steps.detect.outputs.found != 'true'
         run: echo "No frontend toolchain detected; code-quality gate passes by default."
 
-      - name: Set up pnpm
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v6
+      - name: Run code quality (lint/typecheck/test/build)
+        uses: ./.github/actions/pdm-code-quality
         with:
-          version: 11.21.0
-
-      - name: Set up Node.js
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install dependencies
-        if: steps.detect.outputs.has_lockfile == 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        if: steps.detect.outputs.has_lint_script == 'true'
-        run: pnpm run lint
-
-      - name: Typecheck
-        if: steps.detect.outputs.has_typecheck_script == 'true'
-        run: pnpm run typecheck
-
-      - name: Test
-        if: steps.detect.outputs.has_test_script == 'true'
-        run: pnpm test
-
-      - name: Build
-        if: steps.detect.outputs.has_build_script == 'true'
-        run: pnpm run build
+          has_lint_script: ${{ steps.detect.outputs.has_lint_script }}
+          has_typecheck_script: ${{ steps.detect.outputs.has_typecheck_script }}
+          has_test_script: ${{ steps.detect.outputs.has_test_script }}
+          has_build_script: ${{ steps.detect.outputs.has_build_script }}
 
   gate:
     name: PDM Quality Gate (Status Check)

--- a/.github/pdm/workflows/risk-health-check.yml
+++ b/.github/pdm/workflows/risk-health-check.yml
@@ -64,72 +64,20 @@ jobs:
 
       - name: Detect frontend toolchain
         id: detect
-        shell: bash
-        run: |
-          if [[ -f package.json ]]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f pnpm-lock.yaml ]]; then
-            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"lint":' package.json; then
-            echo "has_lint_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lint_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"typecheck":' package.json; then
-            echo "has_typecheck_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_typecheck_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"test":' package.json; then
-            echo "has_test_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_test_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"build":' package.json; then
-            echo "has_build_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_build_script=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/setup-pdm-toolchain
 
       - name: Show health summary
         if: steps.detect.outputs.found != 'true'
         run: echo "No frontend toolchain detected; code-health check passes by default."
 
-      - name: Set up pnpm
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v6
+      - name: Run code health (lint/typecheck/test)
+        uses: ./.github/actions/pdm-code-quality
         with:
-          version: 11.21.0
-
-      - name: Set up Node.js
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install dependencies
-        if: steps.detect.outputs.has_lockfile == 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        if: steps.detect.outputs.has_lint_script == 'true'
-        run: pnpm run lint
-
-      - name: Typecheck
-        if: steps.detect.outputs.has_typecheck_script == 'true'
-        run: pnpm run typecheck
-
-      - name: Test
-        if: steps.detect.outputs.has_test_script == 'true'
-        run: pnpm test
+          run-build: 'false'
+          has_lint_script: ${{ steps.detect.outputs.has_lint_script }}
+          has_typecheck_script: ${{ steps.detect.outputs.has_typecheck_script }}
+          has_test_script: ${{ steps.detect.outputs.has_test_script }}
+          has_build_script: ${{ steps.detect.outputs.has_build_script }}
 
   risk-review:
     name: Diff Risk Review (AI-assisted)

--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -32,36 +32,7 @@ jobs:
 
       - name: Detect frontend toolchain
         id: detect
-        shell: bash
-        run: |
-          if [[ -f package.json ]]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f pnpm-lock.yaml ]]; then
-            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up pnpm
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.21.0
-
-      - name: Set up Node.js
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install dependencies
-        if: steps.detect.outputs.has_lockfile == 'true'
-        run: pnpm install --frozen-lockfile
+        uses: ./.github/actions/setup-pdm-toolchain
 
       - name: Build static export
         if: steps.detect.outputs.found == 'true'

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -57,76 +57,19 @@ jobs:
 
       - name: Detect frontend toolchain
         id: detect
-        shell: bash
-        run: |
-          if [[ -f package.json ]]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f pnpm-lock.yaml ]]; then
-            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"lint":' package.json; then
-            echo "has_lint_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lint_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"typecheck":' package.json; then
-            echo "has_typecheck_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_typecheck_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"test":' package.json; then
-            echo "has_test_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_test_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"build":' package.json; then
-            echo "has_build_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_build_script=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/setup-pdm-toolchain
 
       - name: Note when no frontend
         if: steps.detect.outputs.found != 'true'
         run: echo "No frontend toolchain detected; code-quality gate passes by default."
 
-      - name: Set up pnpm
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v6
+      - name: Run code quality (lint/typecheck/test/build)
+        uses: ./.github/actions/pdm-code-quality
         with:
-          version: 11.21.0
-
-      - name: Set up Node.js
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install dependencies
-        if: steps.detect.outputs.has_lockfile == 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        if: steps.detect.outputs.has_lint_script == 'true'
-        run: pnpm run lint
-
-      - name: Typecheck
-        if: steps.detect.outputs.has_typecheck_script == 'true'
-        run: pnpm run typecheck
-
-      - name: Test
-        if: steps.detect.outputs.has_test_script == 'true'
-        run: pnpm test
-
-      - name: Build
-        if: steps.detect.outputs.has_build_script == 'true'
-        run: pnpm run build
+          has_lint_script: ${{ steps.detect.outputs.has_lint_script }}
+          has_typecheck_script: ${{ steps.detect.outputs.has_typecheck_script }}
+          has_test_script: ${{ steps.detect.outputs.has_test_script }}
+          has_build_script: ${{ steps.detect.outputs.has_build_script }}
 
   gate:
     name: PDM Quality Gate (Status Check)

--- a/.github/workflows/risk-health-check.yml
+++ b/.github/workflows/risk-health-check.yml
@@ -64,72 +64,20 @@ jobs:
 
       - name: Detect frontend toolchain
         id: detect
-        shell: bash
-        run: |
-          if [[ -f package.json ]]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f pnpm-lock.yaml ]]; then
-            echo "has_lockfile=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lockfile=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"lint":' package.json; then
-            echo "has_lint_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_lint_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"typecheck":' package.json; then
-            echo "has_typecheck_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_typecheck_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"test":' package.json; then
-            echo "has_test_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_test_script=false" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ -f package.json ]] && grep -q '"build":' package.json; then
-            echo "has_build_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_build_script=false" >> "$GITHUB_OUTPUT"
-          fi
+        uses: ./.github/actions/setup-pdm-toolchain
 
       - name: Show health summary
         if: steps.detect.outputs.found != 'true'
         run: echo "No frontend toolchain detected; code-health check passes by default."
 
-      - name: Set up pnpm
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: pnpm/action-setup@v6
+      - name: Run code health (lint/typecheck/test)
+        uses: ./.github/actions/pdm-code-quality
         with:
-          version: 11.21.0
-
-      - name: Set up Node.js
-        if: steps.detect.outputs.has_lockfile == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 22
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
-
-      - name: Install dependencies
-        if: steps.detect.outputs.has_lockfile == 'true'
-        run: pnpm install --frozen-lockfile
-
-      - name: Lint
-        if: steps.detect.outputs.has_lint_script == 'true'
-        run: pnpm run lint
-
-      - name: Typecheck
-        if: steps.detect.outputs.has_typecheck_script == 'true'
-        run: pnpm run typecheck
-
-      - name: Test
-        if: steps.detect.outputs.has_test_script == 'true'
-        run: pnpm test
+          run-build: 'false'
+          has_lint_script: ${{ steps.detect.outputs.has_lint_script }}
+          has_typecheck_script: ${{ steps.detect.outputs.has_typecheck_script }}
+          has_test_script: ${{ steps.detect.outputs.has_test_script }}
+          has_build_script: ${{ steps.detect.outputs.has_build_script }}
 
   risk-review:
     name: Diff Risk Review (AI-assisted)


### PR DESCRIPTION
## Summary

Implements **Phase 2** of the Issue #185 rollout plan (`examples/pdm-workflow-templates/ROLLOUT.md`): migrates the three duplicated detect+toolchain+quality inline blocks to the reusable composite actions shipped in Phase 1 (PR #197).

## Changes

| Workflow | Before | After |
|---|---|---|
| `quality-gate.yml` `code-quality` | inline detect + pnpm/Node/install + lint/typecheck/test/build | `setup-pdm-toolchain` + `pdm-code-quality` |
| `risk-health-check.yml` `code-health` | inline detect + pnpm/Node/install + lint/typecheck/test | `setup-pdm-toolchain` + `pdm-code-quality` (`run-build: 'false'`) |
| `publish-pages.yml` `build` | inline detect + pnpm/Node/install + build | `setup-pdm-toolchain` + build step (kept inline for `NEXT_PUBLIC_BASE_PATH`) |

The `detect` step id is preserved everywhere, so downstream `steps.detect.outputs.*` references keep working. E7 in `scripts/examples-test.mjs` is now non-vacuous: it validates the 5 real action references.

## Gates

- `make lint` — actionlint clean, execution copies in sync (`make sync` applied)
- `make test-examples` — 26 pass, 0 fail (E7 now checks real references)
- `make test-scripts` — 7 pass, 0 fail
- Native PR quality gate on this PR is the parity check.

Closes nothing — Issue #185 remains open until Phases 3–4 land.