### PR TITLE
feat(ci): Issue #185 Phase 3 — security-scan & delivery-telemetry templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Workflows are verified by running them on GitHub — no local Docker/`act` harne
 The `examples/` tree ships reference implementations and workflow templates for adopting the PDM framework and AI agent patterns:
 
 - `examples/fintech-agent-runner/` — a minimal opencode agent fleet (`pm`, `delivery-engineer`, `compliance-reviewer`) with scrub-safe definitions, `fleet-sync`, and a local `node --test` hygiene test (ADR 0015 pattern).
-- `examples/pdm-workflow-templates/` — ready-to-copy actionlint-valid workflows: `quality-gate.yml`, `compliance-guardrail.yml`, `agent-runner.yml` (dispatch-only).
+- `examples/pdm-workflow-templates/` — ready-to-copy actionlint-valid workflows: `quality-gate.yml`, `compliance-guardrail.yml`, `security-scan.yml`, `delivery-telemetry.yml`, `agent-runner.yml` (dispatch-only).
 - `examples/agent-skills-demo/` — skill-resolution demo + a dependency-free mocked `node:test` CI scaffold.
 
 Validate them offline, or let the quality gate do it on every PR:

--- a/examples/pdm-workflow-templates/README.md
+++ b/examples/pdm-workflow-templates/README.md
@@ -8,7 +8,11 @@ Reusable GitHub Actions workflow templates for adopting the PDM delivery gates i
 |---|---|---|
 | `templates/quality-gate.yml` | pull_request (develop/main) + dispatch | actionlint on workflows + code-quality steps behind toolchain detection (the required `main` branch-protection check) |
 | `templates/compliance-guardrail.yml` | pull_request + dispatch | trufflehog base..head secret/compliance scan, pass/fail PR comment (guarded on `pull_request.number`) |
+| `templates/security-scan.yml` | schedule + dispatch | weekly gitleaks + OSV re-scan of the default branch (the `google/osv-scanner-action/osv-scanner-action@v2.5.0` + `--recursive .` gotchas, `hashFiles` manifest gating, issue filed on blocking gitleaks findings) |
+| `templates/delivery-telemetry.yml` | schedule + dispatch | weekly DORA + workflow-run telemetry export as run artifacts (the `scripts/delivery-telemetry.mjs` + `scripts/workflow-run-telemetry.mjs` pattern, honest `insufficient-data`) |
 | `templates/agent-runner.yml` | dispatch only | run an opencode agent fleet step (a `make fleet-sync` + agent-invocation example), artifact upload, no PR trigger by construction |
+
+The inventory is pinned in `scripts/examples-test.mjs` (E4-inventory) so a stale or renamed template fails the gate.
 
 Reference versions of `quality-gate` and `compliance-guardrail` live and verified in this repo under `.github/pdm/workflows/`. `agent-runner` is dispatch-only by construction (no PR trigger), so it has no direct canonical counterpart — the closest live reference is `ai-agent-mvp.yml` (PR + dispatch, runs the `ops/agent-runner` tests).
 

--- a/examples/pdm-workflow-templates/ROLLOUT.md
+++ b/examples/pdm-workflow-templates/ROLLOUT.md
@@ -41,10 +41,9 @@ Steps per workflow:
 
 Add whole-workflow templates for the patterns still missing from `examples/pdm-workflow-templates/templates/`:
 
-- `security-scan.yml` — gitleaks + OSV scan capturing the hard-earned gotchas (`google/osv-scanner-action/osv-scanner-action@v2.5.0`, `scan-args: --recursive .`, `hashFiles` gating).
-- `delivery-telemetry.yml` — the DORA + workflow-run telemetry exporter pattern.
-
-Pin the expected inventory in `scripts/examples-test.mjs` (E4) so a stale/renamed template fails the gate.
+- [x] `security-scan.yml` — gitleaks + OSV scan capturing the hard-earned gotchas (`google/osv-scanner-action/osv-scanner-action@v2.5.0`, `scan-args: --recursive .`, `hashFiles` gating).
+- [x] `delivery-telemetry.yml` — the DORA + workflow-run telemetry exporter pattern.
+- [x] Pin the expected inventory in `scripts/examples-test.mjs` (E4) so a stale/renamed template fails the gate.
 
 **Gate:** `make test-examples` with the new inventory pins; actionlint clean.
 

--- a/examples/pdm-workflow-templates/templates/delivery-telemetry.yml
+++ b/examples/pdm-workflow-templates/templates/delivery-telemetry.yml
@@ -1,0 +1,64 @@
+name: PDM Delivery Telemetry
+
+# Template: weekly (plus on-demand) export of GitHub-native delivery telemetry
+# and workflow-run metrics as run artifacts (ADR 0008 / ADR 0006 pattern).
+#   - Reads the Deployments/Releases/Pulls/Issues + Actions runs APIs with the
+#     built-in GITHUB_TOKEN (no external observability service, no new secrets).
+#   - Scans with no matching events are reported `insufficient-data`, never
+#     invented numbers (telemetry-honesty).
+#   - Artifacts are uploaded from the same job that wrote them (cross-job files
+#     do not persist on GitHub), and only on non-PR / schedule runs.
+#   - Requires scripts/delivery-telemetry.mjs + scripts/workflow-run-telemetry.mjs.
+
+on:
+  schedule:
+    - cron: '30 2 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: delivery-telemetry
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  telemetry:
+    name: Collect delivery & workflow-run telemetry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Run delivery telemetry & audit trail exporter
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOOKBACK_DAYS: '90'
+        run: |
+          mkdir -p .github/pdm/reports
+          node scripts/delivery-telemetry.mjs .github/pdm/reports
+          ls -la .github/pdm/reports/delivery-*
+
+      - name: Run workflow-run telemetry & cost estimate
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          LOOKBACK_DAYS: '90'
+        run: |
+          node scripts/workflow-run-telemetry.mjs .github/pdm/reports
+          ls -la .github/pdm/reports/delivery-workflow-runs-*
+
+      - name: Upload delivery telemetry & audit trail
+        uses: actions/upload-artifact@v7
+        with:
+          name: delivery-telemetry
+          path: .github/pdm/reports/delivery-*
+          retention-days: 7

--- a/examples/pdm-workflow-templates/templates/security-scan.yml
+++ b/examples/pdm-workflow-templates/templates/security-scan.yml
@@ -1,0 +1,106 @@
+name: PDM Security Scan
+
+# Template: scheduled + on-demand secret & dependency-vulnerability scan.
+# Captures this repo's hard-earned gotchas so adopters don't rediscover them:
+#   - osv-scanner-action lives in the osv-scanner-action/ subdir; there is no
+#     `google/osv-scanner-action@v1` — use osv-scanner-action@v2.5.0.
+#   - osv-scanner v2 changed -r: use `scan-args: --recursive .` (never `-r=.`).
+#   - the OSV step only runs when dependency manifests exist (hashFiles);
+#     with none it is skipped — that is expected.
+#   - github-script injects context/github; never redeclare them.
+#   - gitleaks findings on schedule runs file an issue via the API.
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: security-scan
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  gitleaks:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Secret scan (gitleaks)
+        uses: gitleaks/gitleaks-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_ENABLE_COMMENTS: "false"
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "false"
+
+  osv:
+    name: Vulnerability scan (OSV)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Vulnerability scan (OSV)
+        if: hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml', '**/requirements*.txt', '**/poetry.lock', '**/Pipfile.lock', '**/Cargo.lock', '**/go.sum', '**/Gemfile.lock', '**/composer.lock', '**/pom.xml', '**/build.gradle*') != ''
+        uses: google/osv-scanner-action/osv-scanner-action@v2.5.0
+        with:
+          scan-args: |-
+            --recursive .
+
+      - name: Note skipped vulnerability scan
+        if: hashFiles('**/package-lock.json', '**/yarn.lock', '**/pnpm-lock.yaml', '**/requirements*.txt', '**/poetry.lock', '**/Pipfile.lock', '**/Cargo.lock', '**/go.sum', '**/Gemfile.lock', '**/composer.lock', '**/pom.xml', '**/build.gradle*') == ''
+        run: echo "No dependency manifests found; vulnerability scan skipped."
+
+  report:
+    name: Scan report
+    if: always()
+    needs: [gitleaks, osv]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Write scan report
+        shell: bash
+        env:
+          GITLEAKS_RESULT: ${{ needs.gitleaks.result }}
+          OSV_RESULT: ${{ needs.osv.result }}
+        run: |
+          mkdir -p .github/pdm/reports
+          report_file=".github/pdm/reports/security-scan-$(date -u +%Y%m%d).md"
+          {
+            echo "## PDM Security Scan — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo ""
+            echo "- **Secrets scan (gitleaks)**: ${GITLEAKS_RESULT}"
+            echo "- **Dependency vulnerabilities (OSV)**: ${OSV_RESULT} (runs when manifests exist; otherwise skipped)"
+            echo "- **Event**: ${{ github.event_name }} — ref ${{ github.ref_name }}"
+            echo ""
+            echo "_Runs weekly (schedule) and on demand (workflow_dispatch). Review any findings and remediate; on schedule runs, blocking gitleaks findings also file an issue._"
+          } > "${report_file}"
+          cp "${report_file}" .github/pdm/reports/security-scan-latest.md
+          echo "Wrote ${report_file}"
+
+      - name: Upload scan report
+        uses: actions/upload-artifact@v7
+        with:
+          name: security-scan-report
+          path: .github/pdm/reports/security-scan-*.md
+          retention-days: 7
+
+      - name: Open issue on blocking secret findings
+        if: needs.gitleaks.result == 'failure' && github.event_name != 'workflow_dispatch'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `[security-scan] gitleaks found secrets (${context.sha.slice(0, 7)})`,
+              body: 'gitleaks reported blocked secret findings on the default branch. See the scan report artifact for details, remediate, and re-run the scan via `workflow_dispatch`.',
+            });

--- a/scripts/examples-test.mjs
+++ b/scripts/examples-test.mjs
@@ -6,6 +6,7 @@
 //   2. the fintech-agent-runner fleet passes its own scrub-rule test
 //   3. the agent-skills-demo contract test passes (mocked "agent runner")
 //   4. the pdm-workflow-templates workflows parse as YAML and pass actionlint
+//      (inventory is pinned to the expected template set — Issue #185)
 //   5. template invariants mirror the repo's gotchas: artifact uploads are
 //      guarded for PR-independent runs, or the trigger is dispatch-only
 //   6. composite actions under .github/actions/ are structurally valid
@@ -22,6 +23,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// Expected whole-workflow template inventory (Issue #185 Phase 3). A stale or
+// renamed template fails E4-inventory so adopters keep an up-to-date copy-me set.
+const TEMPLATE_INVENTORY = [
+  "agent-runner.yml",
+  "compliance-guardrail.yml",
+  "delivery-telemetry.yml",
+  "quality-gate.yml",
+  "security-scan.yml",
+];
 const EXAMPLES = path.resolve(
   process.argv.indexOf("--examples") >= 0
     ? process.argv[process.argv.indexOf("--examples") + 1]
@@ -107,6 +118,12 @@ const finish = () => {
   if (existsSync(templatesDir)) {
     const ymlFiles = readdirSync(templatesDir).filter((f) => f.endsWith(".yml"));
     record("E4", "pdm-workflow-templates has >= 1 template workflow", ymlFiles.length >= 1);
+    record(
+      "E4-inventory",
+      "template inventory matches the pinned set (Issue #185)",
+      JSON.stringify([...ymlFiles].sort()) === JSON.stringify(TEMPLATE_INVENTORY),
+      ymlFiles.sort().join(", ") || "missing",
+    );
 
     // actionlint is required in the quality-gate step and validates full YAML +
     // GitHub expressions. Here we do light structural checks first (zero-dep),


### PR DESCRIPTION
## Summary

Implements **Phase 3** of the Issue #185 rollout plan (`examples/pdm-workflow-templates/ROLLOUT.md`): extend the copy-me template inventory and pin it so the gate stays honest.

## Changes

- **`templates/security-scan.yml`** (new) — weekly + on-demand gitleaks + OSV scan capturing the hard-earned gotchas: `google/osv-scanner-action/osv-scanner-action@v2.5.0` with `scan-args: --recursive .` (never `-r=.`), `hashFiles` manifest gating (skipped when no manifests), github-script without redeclared context, offset-issue on blocking gitleaks findings.
- **`templates/delivery-telemetry.yml`** (new) — weekly + on-demand DORA + workflow-run telemetry exporter (`scripts/delivery-telemetry.mjs` + `scripts/workflow-run-telemetry.mjs`), artifacts uploaded from the same job per ADR 0006, honest `insufficient-data`.
- **`scripts/examples-test.mjs`** — new `E4-inventory` pin: stale/renamed template now fails the gate (inventory constant `TEMPLATE_INVENTORY`).
- README + templates README list the full 5-template inventory; ROLLOUT.md marks Phase 3 complete.

## Gates

- `make lint` — actionlint clean, sync drift-free.
- `make test-examples` — **33 pass, 0 fail** (was 26; +E4-inventory and the 2 new templates).
- `make test-scripts` — 7 pass, 0 fail.

Note: the wiki `[[Workflow-Templates-Rollout]]` status bullet references this PR number — I'll update it to the real number in the wiki after merges land. Issue #185 Phase 5 (enterprise hardening) remains as follow-ups.